### PR TITLE
sediment: Add Apple icon and GitHub links

### DIFF
--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import ".next/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/src/app/apple-icon.tsx
+++ b/frontend/src/app/apple-icon.tsx
@@ -8,8 +8,8 @@ export default function AppleIcon() {
     (
       <div
         style={{
-          width: 180,
-          height: 180,
+          width: size.width,
+          height: size.height,
           background: "#1a1108",
           display: "flex",
           alignItems: "center",

--- a/frontend/src/app/apple-icon.tsx
+++ b/frontend/src/app/apple-icon.tsx
@@ -1,0 +1,38 @@
+import { ImageResponse } from "next/og";
+
+export const size = { width: 180, height: 180 };
+export const contentType = "image/png";
+
+export default function AppleIcon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: 180,
+          height: 180,
+          background: "#1a1108",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          borderRadius: 40,
+        }}
+      >
+        <svg
+          width="100"
+          height="100"
+          viewBox="0 0 64 64"
+          fill="none"
+          stroke="#e0894d"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2.75"
+        >
+          <path d="M14 42l18 7 18-7" opacity="0.35" />
+          <path d="M14 33l18 7 18-7" opacity="0.65" />
+          <path d="M32 15L14 24l18 9 18-9-18-9z" />
+        </svg>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -6,6 +6,10 @@ import "katex/dist/katex.min.css";
 export const metadata: Metadata = {
   title: "Sediment — Knowledge, layered.",
   description: "Trace any research concept back through time.",
+  appleWebApp: {
+    capable: true,
+    title: "Sediment",
+  },
 };
 
 export default function RootLayout({

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -23,6 +23,8 @@ import { buildTimelineFromGraph, mergeTimelineWithGraph } from "@/lib/timeline-b
 import { SavedGraphListItem, SeedCandidate, TimelineData, TraversalSettings } from "@/lib/types";
 import { exportObsidianZip } from "@/lib/export";
 
+const GITHUB_REPO_URL = "https://github.com/shresthkapoor7/sediment";
+
 const DEFAULT_SETTINGS: TraversalSettings = {
   depth: 1,
   breadth: 2,
@@ -834,7 +836,7 @@ export default function Home() {
           </AnimatePresence>
 
           <a
-            href="https://github.com/shresthkapoor7/sediment"
+            href={GITHUB_REPO_URL}
             target="_blank"
             rel="noopener noreferrer"
             aria-label="View on GitHub"
@@ -1269,7 +1271,7 @@ export default function Home() {
                   />
                 ))}
                 <a
-                  href="https://github.com/shresthkapoor7/sediment"
+                  href={GITHUB_REPO_URL}
                   target="_blank"
                   rel="noopener noreferrer"
                   style={{

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -833,6 +833,37 @@ export default function Home() {
             )}
           </AnimatePresence>
 
+          <a
+            href="https://github.com/shresthkapoor7/sediment"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="View on GitHub"
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              width: "2rem",
+              height: "2rem",
+              borderRadius: "0.4375rem",
+              border: "0.0625rem solid var(--border)",
+              color: "var(--text-secondary)",
+              transition: "border-color 0.15s, color 0.15s",
+              flexShrink: 0,
+            }}
+            onMouseEnter={(e) => {
+              (e.currentTarget as HTMLAnchorElement).style.borderColor = "var(--accent)";
+              (e.currentTarget as HTMLAnchorElement).style.color = "var(--accent)";
+            }}
+            onMouseLeave={(e) => {
+              (e.currentTarget as HTMLAnchorElement).style.borderColor = "var(--border)";
+              (e.currentTarget as HTMLAnchorElement).style.color = "var(--text-secondary)";
+            }}
+          >
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M12 2C6.477 2 2 6.477 2 12c0 4.418 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.009-.868-.013-1.703-2.782.604-3.369-1.342-3.369-1.342-.454-1.155-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0 1 12 6.836a9.59 9.59 0 0 1 2.504.337c1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.741 0 .267.18.578.688.48C19.138 20.163 22 16.418 22 12c0-5.523-4.477-10-10-10z" />
+            </svg>
+          </a>
+
           <ThemeToggle />
         </div>
       </motion.header>
@@ -1210,7 +1241,7 @@ export default function Home() {
                 </motion.div>
               )}
 
-              {/* Decorative strata lines */}
+              {/* Decorative strata lines + GitHub link */}
               <motion.div
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
@@ -1237,6 +1268,34 @@ export default function Home() {
                     }}
                   />
                 ))}
+                <a
+                  href="https://github.com/shresthkapoor7/sediment"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{
+                    marginTop: "0.75rem",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "0.375rem",
+                    fontSize: "0.6875rem",
+                    color: "var(--text-tertiary)",
+                    fontFamily: "'JetBrains Mono', monospace",
+                    letterSpacing: "0.04em",
+                    textDecoration: "none",
+                    transition: "color 0.15s",
+                  }}
+                  onMouseEnter={(e) => {
+                    (e.currentTarget as HTMLAnchorElement).style.color = "var(--accent)";
+                  }}
+                  onMouseLeave={(e) => {
+                    (e.currentTarget as HTMLAnchorElement).style.color = "var(--text-tertiary)";
+                  }}
+                >
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M12 2C6.477 2 2 6.477 2 12c0 4.418 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.009-.868-.013-1.703-2.782.604-3.369-1.342-3.369-1.342-.454-1.155-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0 1 12 6.836a9.59 9.59 0 0 1 2.504.337c1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.741 0 .267.18.578.688.48C19.138 20.163 22 16.418 22 12c0-5.523-4.477-10-10-10z" />
+                  </svg>
+                  open source
+                </a>
               </motion.div>
             </motion.div>
           ) : isSearching || isRestoring ? (


### PR DESCRIPTION
- add generated apple touch icon metadata
- link the app header and homepage to the GitHub repo
- fix the Next types import path in `next-env.d.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Apple web app icon support for iOS installations and compatibility
  * Added GitHub repository links accessible from both the top navigation bar and landing page for easy project access
  * Enhanced mobile web app experience with Apple web app metadata configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->