### PR TITLE
sediment: added the ability to delete nodes and color them

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -2112,10 +2112,13 @@ export default function Home() {
           return;
         }
         const nextTimelineData = buildTimelineFromGraph(response);
+        const nextSeedPaperId =
+          response.seedPaperId ??
+          seedOpenalexId ??
+          nextTimelineData.nodes[nextTimelineData.rootId]?.paper.openalexId ??
+          null;
         setTimelineData(nextTimelineData);
-        setSelectedSeedOpenalexId(
-          response.seedPaperId ?? seedOpenalexId ?? null,
-        );
+        setSelectedSeedOpenalexId(nextSeedPaperId);
 
         if (userId) {
           try {
@@ -2124,7 +2127,7 @@ export default function Home() {
               userId,
               query,
               data: nextTimelineData,
-              seedPaperId: response.seedPaperId,
+              seedPaperId: nextSeedPaperId,
               metadata: buildMetadata(query, nextTimelineData),
             });
             setGraphId(savedGraph.id);
@@ -2296,7 +2299,7 @@ export default function Home() {
 
   const handleTimelineGraphAction = useCallback(
     (action: TimelineGraphAction) => {
-      if (!timelineData) return;
+      if (!timelineData || isExpanding) return;
       const nextTimelineData = applyTimelineGraphAction(timelineData, action, {
         lockedOpenalexIds: selectedSeedOpenalexId ? [selectedSeedOpenalexId] : [],
       });
@@ -2304,7 +2307,7 @@ export default function Home() {
       setTimelineData(nextTimelineData);
       scheduleGraphUpdate(nextTimelineData, searchedQuery);
     },
-    [scheduleGraphUpdate, searchedQuery, selectedSeedOpenalexId, timelineData],
+    [isExpanding, scheduleGraphUpdate, searchedQuery, selectedSeedOpenalexId, timelineData],
   );
 
   const handleRefreshCurrent = useCallback(() => {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -25,6 +25,7 @@ import {
   updateSavedGraph,
 } from "@/lib/api";
 import { useHoverPreviewToggle } from "@/lib/hover-preview";
+import { applyTimelineGraphAction } from "@/lib/timeline-actions";
 import {
   buildTimelineFromGraph,
   mergeTimelineWithGraph,
@@ -33,6 +34,7 @@ import {
   SavedGraphListItem,
   SeedCandidate,
   TimelineData,
+  TimelineGraphAction,
   TraversalSettings,
 } from "@/lib/types";
 import { exportObsidianZip } from "@/lib/export";
@@ -2049,8 +2051,7 @@ export default function Home() {
           userId,
           query: nextQuery,
           data: nextData,
-          seedPaperId:
-            nextData.nodes[nextData.rootId]?.paper.openalexId ?? null,
+          seedPaperId: selectedSeedOpenalexId ?? nextData.nodes[nextData.rootId]?.paper.openalexId ?? null,
           metadata: buildMetadata(nextQuery, nextData),
         })
           .then(() => {
@@ -2064,7 +2065,7 @@ export default function Home() {
           });
       }, 700);
     },
-    [buildMetadata, graphId, userId],
+    [buildMetadata, graphId, selectedSeedOpenalexId, userId],
   );
 
   const runSearch = useCallback(
@@ -2291,6 +2292,19 @@ export default function Home() {
       settings,
       timelineData,
     ],
+  );
+
+  const handleTimelineGraphAction = useCallback(
+    (action: TimelineGraphAction) => {
+      if (!timelineData) return;
+      const nextTimelineData = applyTimelineGraphAction(timelineData, action, {
+        lockedOpenalexIds: selectedSeedOpenalexId ? [selectedSeedOpenalexId] : [],
+      });
+      if (nextTimelineData === timelineData) return;
+      setTimelineData(nextTimelineData);
+      scheduleGraphUpdate(nextTimelineData, searchedQuery);
+    },
+    [scheduleGraphUpdate, searchedQuery, selectedSeedOpenalexId, timelineData],
   );
 
   const handleRefreshCurrent = useCallback(() => {
@@ -4492,6 +4506,8 @@ export default function Home() {
               <TimelineCanvas
                 data={timelineData!}
                 onExpandNode={handleExpandNode}
+                onGraphAction={handleTimelineGraphAction}
+                lockedNodeOpenalexId={selectedSeedOpenalexId}
                 isExpanding={isExpanding}
                 onUsageChanged={refreshCredits}
                 hoverPreviewEnabled={hoverPreviewEnabled}

--- a/frontend/src/components/TimelineCanvas.tsx
+++ b/frontend/src/components/TimelineCanvas.tsx
@@ -5,7 +5,8 @@ import { motion, AnimatePresence } from "framer-motion";
 import { MarkdownContent } from "./MarkdownContent";
 import { fetchPaperAccess, openChatSession, streamChatAboutPaper } from "@/lib/api";
 import { TIMELINE_MOBILE_BREAKPOINT_PX } from "@/lib/hover-preview";
-import { TimelineData, ChatSuggestion, PaperAccessResponse, TimelineNode, PaperChatStreamEvent } from "@/lib/types";
+import { TimelineData, ChatSuggestion, PaperAccessResponse, TimelineNode, PaperChatStreamEvent, TimelineGraphAction, NodeBorderColor } from "@/lib/types";
+import { NODE_BORDER_COLOR_OPTIONS, nodeBorderColorCss } from "@/lib/node-style";
 import { NODE_DIMENSIONS } from "@/lib/dummy-data";
 import { TimelineNodeCard } from "./TimelineNode";
 import { TimelineEdgeLine } from "./TimelineEdge";
@@ -36,6 +37,8 @@ interface ToolEvent {
 interface TimelineCanvasProps {
   data: TimelineData;
   onExpandNode: (nodeId: number, query: string) => void;
+  onGraphAction?: (action: TimelineGraphAction) => void;
+  lockedNodeOpenalexId?: string | null;
   isExpanding: boolean;
   onUsageChanged?: () => void;
   readOnly?: boolean;
@@ -61,6 +64,8 @@ type PaperAccessState = PaperAccessResponse | {
 export function TimelineCanvas({
   data,
   onExpandNode,
+  onGraphAction,
+  lockedNodeOpenalexId,
   isExpanding,
   onUsageChanged,
   readOnly = false,
@@ -639,6 +644,9 @@ export function TimelineCanvas({
   }
 
   const activeNode = activeNodeId ? data.nodes[activeNodeId] : null;
+  const isActiveNodeLocked = Boolean(
+    activeNode && (activeNode.id === data.rootId || activeNode.paper.openalexId === lockedNodeOpenalexId),
+  );
   const activePaperHref = activeNode ? getPaperHref(activeNode) : null;
   const activePaperAccess = activeNode
     ? paperAccessById[activeNode.paper.openalexId] ?? {
@@ -796,6 +804,30 @@ export function TimelineCanvas({
     },
     [activeNodeId, onExpandNode]
   );
+
+  const handleSetNodeBorderColor = useCallback(
+    (borderColor: NodeBorderColor | null) => {
+      if (!activeNodeId || readOnly) return;
+      onGraphAction?.({ type: "highlight_node", nodeId: activeNodeId, borderColor });
+    },
+    [activeNodeId, onGraphAction, readOnly],
+  );
+
+  const handleDeleteActiveNode = useCallback(() => {
+    const activeNode = activeNodeId ? data.nodes[activeNodeId] : null;
+    if (
+      !activeNodeId ||
+      !activeNode ||
+      readOnly ||
+      activeNodeId === data.rootId ||
+      activeNode.paper.openalexId === lockedNodeOpenalexId ||
+      Object.keys(data.nodes).length <= 1
+    ) {
+      return;
+    }
+    onGraphAction?.({ type: "delete_node", nodeId: activeNodeId });
+    setActiveNodeId(null);
+  }, [activeNodeId, data.nodes, data.rootId, lockedNodeOpenalexId, onGraphAction, readOnly]);
 
   const hasExistingExpansion = useCallback(
     (sourceNodeId: number, query: string) =>
@@ -1031,6 +1063,11 @@ export function TimelineCanvas({
           <marker id="arrow-cross" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto" markerUnits="strokeWidth">
             <path d="M0,0 L0,6 L8,3 z" fill="var(--edge-color)" opacity="0.5" />
           </marker>
+          {NODE_BORDER_COLOR_OPTIONS.map((color) => (
+            <marker key={color.key} id={`arrow-colored-${color.key}`} markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto" markerUnits="strokeWidth">
+              <path d="M0,0 L0,6 L8,3 z" fill={color.css} opacity="0.88" />
+            </marker>
+          ))}
         </defs>
         <g ref={gRef}>
           {/* Edges — derived from adjacency list */}
@@ -1050,6 +1087,7 @@ export function TimelineCanvas({
                 isActive={isActive}
                 isCrossLane={isCrossLane}
                 isInferred={edge.relation === "inferred"}
+                strokeColor={from.annotation?.borderColor ? nodeBorderColorCss(from.annotation.borderColor) : null}
               />
             );
           })}
@@ -1674,6 +1712,107 @@ export function TimelineCanvas({
                   </p>
                 )}
               </div>
+
+              {!readOnly && onGraphAction && (
+                <div
+                  style={{
+                    background: "var(--bg-secondary)",
+                    border: "0.0625rem solid var(--border)",
+                    borderRadius: "0.625rem",
+                    padding: "0.75rem 0.875rem",
+                    marginBottom: "1.25rem",
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: "0.625rem",
+                  }}
+                >
+                  <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "0.75rem" }}>
+                    <p
+                      style={{
+                        fontSize: "0.625rem",
+                        color: "var(--text-tertiary)",
+                        fontFamily: "'JetBrains Mono', monospace",
+                        letterSpacing: "0.06em",
+                        textTransform: "uppercase",
+                      }}
+                    >
+                      Graph controls
+                    </p>
+                    {activeNode.annotation?.borderColor && (
+                      <button
+                        type="button"
+                        onClick={() => handleSetNodeBorderColor(null)}
+                        style={{
+                          background: "none",
+                          border: "none",
+                          color: "var(--text-tertiary)",
+                          cursor: "pointer",
+                          fontSize: "0.625rem",
+                          fontFamily: "'JetBrains Mono', monospace",
+                          padding: 0,
+                        }}
+                      >
+                        Clear border
+                      </button>
+                    )}
+                  </div>
+
+                  <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "0.75rem" }}>
+                    <div style={{ display: "flex", gap: "0.375rem", flexWrap: "wrap" }}>
+                      {NODE_BORDER_COLOR_OPTIONS.map((color) => {
+                        const selected = activeNode.annotation?.borderColor === color.key;
+                        return (
+                          <button
+                            key={color.key}
+                            type="button"
+                            title={`Set ${color.label.toLowerCase()} border`}
+                            aria-label={`Set ${color.label.toLowerCase()} border`}
+                            onClick={() => handleSetNodeBorderColor(color.key)}
+                            style={{
+                              width: "1.375rem",
+                              height: "1.375rem",
+                              borderRadius: "999px",
+                              border: `0.125rem solid ${selected ? "var(--text-primary)" : "var(--border)"}`,
+                              background: color.css,
+                              cursor: "pointer",
+                              boxShadow: selected ? `0 0 0 0.1875rem color-mix(in srgb, ${color.css} 28%, transparent)` : "none",
+                            }}
+                          />
+                        );
+                      })}
+                    </div>
+
+                    <button
+                      type="button"
+                      onClick={handleDeleteActiveNode}
+                      disabled={isActiveNodeLocked || Object.keys(data.nodes).length <= 1}
+                      style={{
+                        flexShrink: 0,
+                        background: "var(--bg-primary)",
+                        border: "0.0625rem solid var(--border)",
+                        borderRadius: "0.4375rem",
+                        color: isActiveNodeLocked || Object.keys(data.nodes).length <= 1 ? "var(--text-tertiary)" : "var(--text-secondary)",
+                        cursor: isActiveNodeLocked || Object.keys(data.nodes).length <= 1 ? "default" : "pointer",
+                        fontSize: "0.6875rem",
+                        fontWeight: 600,
+                        fontFamily: "'DM Sans', sans-serif",
+                        padding: "0.375rem 0.625rem",
+                      }}
+                      onMouseEnter={(e) => {
+                        if (isActiveNodeLocked || Object.keys(data.nodes).length <= 1) return;
+                        e.currentTarget.style.borderColor = "var(--accent)";
+                        e.currentTarget.style.color = "var(--accent)";
+                      }}
+                      onMouseLeave={(e) => {
+                        e.currentTarget.style.borderColor = "var(--border)";
+                        e.currentTarget.style.color = isActiveNodeLocked || Object.keys(data.nodes).length <= 1 ? "var(--text-tertiary)" : "var(--text-secondary)";
+                      }}
+                    >
+                      {isActiveNodeLocked ? "Seed locked" : "Remove node"}
+                    </button>
+                  </div>
+                </div>
+              )}
 
               {/* Chat messages */}
               {(chatHistories[activeNodeId] ?? []).map((msg) => (

--- a/frontend/src/components/TimelineCanvas.tsx
+++ b/frontend/src/components/TimelineCanvas.tsx
@@ -6,7 +6,7 @@ import { MarkdownContent } from "./MarkdownContent";
 import { fetchPaperAccess, openChatSession, streamChatAboutPaper } from "@/lib/api";
 import { TIMELINE_MOBILE_BREAKPOINT_PX } from "@/lib/hover-preview";
 import { TimelineData, ChatSuggestion, PaperAccessResponse, TimelineNode, PaperChatStreamEvent, TimelineGraphAction, NodeBorderColor } from "@/lib/types";
-import { NODE_BORDER_COLOR_OPTIONS, nodeBorderColorCss } from "@/lib/node-style";
+import { NODE_BORDER_COLOR_OPTIONS } from "@/lib/node-style";
 import { NODE_DIMENSIONS } from "@/lib/dummy-data";
 import { TimelineNodeCard } from "./TimelineNode";
 import { TimelineEdgeLine } from "./TimelineEdge";
@@ -647,6 +647,7 @@ export function TimelineCanvas({
   const isActiveNodeLocked = Boolean(
     activeNode && (activeNode.id === data.rootId || activeNode.paper.openalexId === lockedNodeOpenalexId),
   );
+  const graphActionsDisabled = readOnly || isExpanding;
   const activePaperHref = activeNode ? getPaperHref(activeNode) : null;
   const activePaperAccess = activeNode
     ? paperAccessById[activeNode.paper.openalexId] ?? {
@@ -807,10 +808,10 @@ export function TimelineCanvas({
 
   const handleSetNodeBorderColor = useCallback(
     (borderColor: NodeBorderColor | null) => {
-      if (!activeNodeId || readOnly) return;
+      if (!activeNodeId || graphActionsDisabled) return;
       onGraphAction?.({ type: "highlight_node", nodeId: activeNodeId, borderColor });
     },
-    [activeNodeId, onGraphAction, readOnly],
+    [activeNodeId, graphActionsDisabled, onGraphAction],
   );
 
   const handleDeleteActiveNode = useCallback(() => {
@@ -818,7 +819,7 @@ export function TimelineCanvas({
     if (
       !activeNodeId ||
       !activeNode ||
-      readOnly ||
+      graphActionsDisabled ||
       activeNodeId === data.rootId ||
       activeNode.paper.openalexId === lockedNodeOpenalexId ||
       Object.keys(data.nodes).length <= 1
@@ -827,7 +828,7 @@ export function TimelineCanvas({
     }
     onGraphAction?.({ type: "delete_node", nodeId: activeNodeId });
     setActiveNodeId(null);
-  }, [activeNodeId, data.nodes, data.rootId, lockedNodeOpenalexId, onGraphAction, readOnly]);
+  }, [activeNodeId, data.nodes, data.rootId, graphActionsDisabled, lockedNodeOpenalexId, onGraphAction]);
 
   const hasExistingExpansion = useCallback(
     (sourceNodeId: number, query: string) =>
@@ -1087,7 +1088,7 @@ export function TimelineCanvas({
                 isActive={isActive}
                 isCrossLane={isCrossLane}
                 isInferred={edge.relation === "inferred"}
-                strokeColor={from.annotation?.borderColor ? nodeBorderColorCss(from.annotation.borderColor) : null}
+                annotationColor={from.annotation?.borderColor ?? null}
               />
             );
           })}
@@ -1742,11 +1743,12 @@ export function TimelineCanvas({
                       <button
                         type="button"
                         onClick={() => handleSetNodeBorderColor(null)}
+                        disabled={graphActionsDisabled}
                         style={{
                           background: "none",
                           border: "none",
                           color: "var(--text-tertiary)",
-                          cursor: "pointer",
+                          cursor: graphActionsDisabled ? "default" : "pointer",
                           fontSize: "0.625rem",
                           fontFamily: "'JetBrains Mono', monospace",
                           padding: 0,
@@ -1768,13 +1770,15 @@ export function TimelineCanvas({
                             title={`Set ${color.label.toLowerCase()} border`}
                             aria-label={`Set ${color.label.toLowerCase()} border`}
                             onClick={() => handleSetNodeBorderColor(color.key)}
+                            disabled={graphActionsDisabled}
                             style={{
                               width: "1.375rem",
                               height: "1.375rem",
                               borderRadius: "999px",
                               border: `0.125rem solid ${selected ? "var(--text-primary)" : "var(--border)"}`,
                               background: color.css,
-                              cursor: "pointer",
+                              cursor: graphActionsDisabled ? "default" : "pointer",
+                              opacity: graphActionsDisabled ? 0.55 : 1,
                               boxShadow: selected ? `0 0 0 0.1875rem color-mix(in srgb, ${color.css} 28%, transparent)` : "none",
                             }}
                           />
@@ -1785,30 +1789,30 @@ export function TimelineCanvas({
                     <button
                       type="button"
                       onClick={handleDeleteActiveNode}
-                      disabled={isActiveNodeLocked || Object.keys(data.nodes).length <= 1}
+                      disabled={graphActionsDisabled || isActiveNodeLocked || Object.keys(data.nodes).length <= 1}
                       style={{
                         flexShrink: 0,
                         background: "var(--bg-primary)",
                         border: "0.0625rem solid var(--border)",
                         borderRadius: "0.4375rem",
-                        color: isActiveNodeLocked || Object.keys(data.nodes).length <= 1 ? "var(--text-tertiary)" : "var(--text-secondary)",
-                        cursor: isActiveNodeLocked || Object.keys(data.nodes).length <= 1 ? "default" : "pointer",
+                        color: graphActionsDisabled || isActiveNodeLocked || Object.keys(data.nodes).length <= 1 ? "var(--text-tertiary)" : "var(--text-secondary)",
+                        cursor: graphActionsDisabled || isActiveNodeLocked || Object.keys(data.nodes).length <= 1 ? "default" : "pointer",
                         fontSize: "0.6875rem",
                         fontWeight: 600,
                         fontFamily: "'DM Sans', sans-serif",
                         padding: "0.375rem 0.625rem",
                       }}
                       onMouseEnter={(e) => {
-                        if (isActiveNodeLocked || Object.keys(data.nodes).length <= 1) return;
+                        if (graphActionsDisabled || isActiveNodeLocked || Object.keys(data.nodes).length <= 1) return;
                         e.currentTarget.style.borderColor = "var(--accent)";
                         e.currentTarget.style.color = "var(--accent)";
                       }}
                       onMouseLeave={(e) => {
                         e.currentTarget.style.borderColor = "var(--border)";
-                        e.currentTarget.style.color = isActiveNodeLocked || Object.keys(data.nodes).length <= 1 ? "var(--text-tertiary)" : "var(--text-secondary)";
+                        e.currentTarget.style.color = graphActionsDisabled || isActiveNodeLocked || Object.keys(data.nodes).length <= 1 ? "var(--text-tertiary)" : "var(--text-secondary)";
                       }}
                     >
-                      {isActiveNodeLocked ? "Seed locked" : "Remove node"}
+                      {isExpanding ? "Expanding..." : isActiveNodeLocked ? "Seed locked" : "Remove node"}
                     </button>
                   </div>
                 </div>

--- a/frontend/src/components/TimelineEdge.tsx
+++ b/frontend/src/components/TimelineEdge.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { TimelineNode } from "@/lib/types";
+import { NodeBorderColor, TimelineNode } from "@/lib/types";
 import { NODE_DIMENSIONS } from "@/lib/dummy-data";
+import { nodeBorderColorCss } from "@/lib/node-style";
 
 interface TimelineEdgeProps {
   from: TimelineNode;
@@ -11,7 +12,7 @@ interface TimelineEdgeProps {
   isActive: boolean;
   isCrossLane?: boolean;
   isInferred?: boolean;
-  strokeColor?: string | null;
+  annotationColor?: NodeBorderColor | null;
 }
 
 export function TimelineEdgeLine({
@@ -21,7 +22,7 @@ export function TimelineEdgeLine({
   isActive,
   isCrossLane = false,
   isInferred = false,
-  strokeColor = null,
+  annotationColor = null,
 }: TimelineEdgeProps) {
   const { width, height } = NODE_DIMENSIONS;
 
@@ -36,17 +37,21 @@ export function TimelineEdgeLine({
   const midX = (x1 + x2) / 2;
   const path = `M ${x1} ${y1} C ${midX} ${y1}, ${midX} ${y2}, ${x2} ${y2}`;
 
-  const colored = Boolean(strokeColor && !isActive);
+  const colored = Boolean(annotationColor && !isActive);
   const markerId = isActive
     ? "arrow-active"
     : colored
-      ? `arrow-colored-${from.annotation?.borderColor}`
+      ? `arrow-colored-${annotationColor}`
       : isInferred || isCrossLane
         ? "arrow-cross"
         : "arrow-default";
   const strokeDasharray = isInferred ? "6 4" : isCrossLane ? "4 3" : undefined;
   const baseOpacity = isActive ? 1 : colored ? 0.88 : isInferred ? 0.42 : isCrossLane ? 0.5 : 0.7;
-  const stroke = isActive ? "var(--edge-color-active)" : strokeColor ?? "var(--edge-color)";
+  const stroke = isActive
+    ? "var(--edge-color-active)"
+    : annotationColor
+      ? nodeBorderColorCss(annotationColor)
+      : "var(--edge-color)";
 
   return (
     <g>

--- a/frontend/src/components/TimelineEdge.tsx
+++ b/frontend/src/components/TimelineEdge.tsx
@@ -11,6 +11,7 @@ interface TimelineEdgeProps {
   isActive: boolean;
   isCrossLane?: boolean;
   isInferred?: boolean;
+  strokeColor?: string | null;
 }
 
 export function TimelineEdgeLine({
@@ -20,6 +21,7 @@ export function TimelineEdgeLine({
   isActive,
   isCrossLane = false,
   isInferred = false,
+  strokeColor = null,
 }: TimelineEdgeProps) {
   const { width, height } = NODE_DIMENSIONS;
 
@@ -34,9 +36,17 @@ export function TimelineEdgeLine({
   const midX = (x1 + x2) / 2;
   const path = `M ${x1} ${y1} C ${midX} ${y1}, ${midX} ${y2}, ${x2} ${y2}`;
 
-  const markerId = isActive ? "arrow-active" : isInferred || isCrossLane ? "arrow-cross" : "arrow-default";
+  const colored = Boolean(strokeColor && !isActive);
+  const markerId = isActive
+    ? "arrow-active"
+    : colored
+      ? `arrow-colored-${from.annotation?.borderColor}`
+      : isInferred || isCrossLane
+        ? "arrow-cross"
+        : "arrow-default";
   const strokeDasharray = isInferred ? "6 4" : isCrossLane ? "4 3" : undefined;
-  const baseOpacity = isActive ? 1 : isInferred ? 0.42 : isCrossLane ? 0.5 : 0.7;
+  const baseOpacity = isActive ? 1 : colored ? 0.88 : isInferred ? 0.42 : isCrossLane ? 0.5 : 0.7;
+  const stroke = isActive ? "var(--edge-color-active)" : strokeColor ?? "var(--edge-color)";
 
   return (
     <g>
@@ -63,8 +73,8 @@ export function TimelineEdgeLine({
       <motion.path
         d={path}
         fill="none"
-        stroke={isActive ? "var(--edge-color-active)" : "var(--edge-color)"}
-        strokeWidth={isActive ? 2 : 1.5}
+        stroke={stroke}
+        strokeWidth={isActive || colored ? 2 : 1.5}
         strokeLinecap="round"
         strokeDasharray={strokeDasharray}
         markerEnd={`url(#${markerId})`}

--- a/frontend/src/components/TimelineNode.tsx
+++ b/frontend/src/components/TimelineNode.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from "framer-motion";
 import { TimelineNode as TNode } from "@/lib/types";
+import { nodeBorderColorCss } from "@/lib/node-style";
 import { NODE_DIMENSIONS } from "@/lib/dummy-data";
 
 interface TimelineNodeProps {
@@ -26,13 +27,16 @@ export function TimelineNodeCard({
   shouldAnimate,
 }: TimelineNodeProps) {
   const { width, height } = NODE_DIMENSIONS;
+  const annotationColor = node.annotation?.borderColor ? nodeBorderColorCss(node.annotation.borderColor) : null;
   const getBorderColor = (active: boolean, highlighted: boolean) =>
-    active || highlighted ? "var(--accent)" : "var(--node-border)";
+    active || highlighted ? "var(--accent)" : annotationColor ?? "var(--node-border)";
   const getBoxShadow = (active: boolean, highlighted: boolean) =>
     active
       ? "0 0 0 0.1875rem var(--accent-soft), var(--node-shadow)"
       : highlighted
         ? "0 0 0 0.1875rem var(--accent-soft), 0 0 1rem var(--accent-glow), var(--node-shadow)"
+        : annotationColor
+          ? `0 0 0 0.15625rem color-mix(in srgb, ${annotationColor} 28%, transparent), var(--node-shadow)`
         : "var(--node-shadow)";
   const getHoverBoxShadow = () => "var(--node-shadow-hover)";
   const borderColor = getBorderColor(isActive, isHighlighted);

--- a/frontend/src/lib/node-style.ts
+++ b/frontend/src/lib/node-style.ts
@@ -1,0 +1,14 @@
+import { NodeBorderColor } from "./types";
+
+export const NODE_BORDER_COLOR_OPTIONS: Array<{ key: NodeBorderColor; css: string; label: string }> = [
+  { key: "accent", css: "var(--accent)", label: "Accent" },
+  { key: "blue", css: "#60a5fa", label: "Blue" },
+  { key: "green", css: "#34d399", label: "Green" },
+  { key: "purple", css: "#a78bfa", label: "Purple" },
+  { key: "amber", css: "#f59e0b", label: "Amber" },
+  { key: "rose", css: "#fb7185", label: "Rose" },
+];
+
+export function nodeBorderColorCss(color: NodeBorderColor): string {
+  return NODE_BORDER_COLOR_OPTIONS.find((option) => option.key === color)?.css ?? "var(--accent)";
+}

--- a/frontend/src/lib/node-style.ts
+++ b/frontend/src/lib/node-style.ts
@@ -1,14 +1,20 @@
 import { NodeBorderColor } from "./types";
 
-export const NODE_BORDER_COLOR_OPTIONS: Array<{ key: NodeBorderColor; css: string; label: string }> = [
-  { key: "accent", css: "var(--accent)", label: "Accent" },
-  { key: "blue", css: "#60a5fa", label: "Blue" },
-  { key: "green", css: "#34d399", label: "Green" },
-  { key: "purple", css: "#a78bfa", label: "Purple" },
-  { key: "amber", css: "#f59e0b", label: "Amber" },
-  { key: "rose", css: "#fb7185", label: "Rose" },
-];
+const NODE_BORDER_COLOR_MAP: Record<NodeBorderColor, { css: string; label: string }> = {
+  accent: { css: "var(--accent)", label: "Accent" },
+  blue: { css: "#60a5fa", label: "Blue" },
+  green: { css: "#34d399", label: "Green" },
+  purple: { css: "#a78bfa", label: "Purple" },
+  amber: { css: "#f59e0b", label: "Amber" },
+  rose: { css: "#fb7185", label: "Rose" },
+};
+
+export const NODE_BORDER_COLOR_OPTIONS: Array<{ key: NodeBorderColor; css: string; label: string }> =
+  Object.entries(NODE_BORDER_COLOR_MAP).map(([key, value]) => ({
+    key: key as NodeBorderColor,
+    ...value,
+  }));
 
 export function nodeBorderColorCss(color: NodeBorderColor): string {
-  return NODE_BORDER_COLOR_OPTIONS.find((option) => option.key === color)?.css ?? "var(--accent)";
+  return NODE_BORDER_COLOR_MAP[color].css;
 }

--- a/frontend/src/lib/timeline-actions.ts
+++ b/frontend/src/lib/timeline-actions.ts
@@ -167,7 +167,7 @@ function collectDescendantIds(
 
 function computeGenerationFromParents(nodeId: number, nodes: Record<number, TimelineNode>): number {
   const parentId = nodes[nodeId]?.parentId;
-  if (!parentId || !nodes[parentId]) {
+  if (parentId === null || parentId === undefined || !nodes[parentId]) {
     return 0;
   }
   return nodes[parentId].generation + 1;

--- a/frontend/src/lib/timeline-actions.ts
+++ b/frontend/src/lib/timeline-actions.ts
@@ -1,0 +1,137 @@
+import { NodeBorderColor, TimelineData, TimelineGraphAction, TimelineNode } from "./types";
+
+interface TimelineGraphActionOptions {
+  lockedOpenalexIds?: string[];
+}
+
+export function applyTimelineGraphAction(
+  data: TimelineData,
+  action: TimelineGraphAction,
+  options: TimelineGraphActionOptions = {},
+): TimelineData {
+  if (action.type === "highlight_node") {
+    return applyNodeHighlight(data, action.nodeId, action.borderColor);
+  }
+  if (action.type === "delete_node") {
+    return applyNodeDeletion(data, action.nodeId, options);
+  }
+  return data;
+}
+
+function applyNodeHighlight(
+  data: TimelineData,
+  nodeId: number,
+  borderColor: NodeBorderColor | null,
+): TimelineData {
+  const node = data.nodes[nodeId];
+  if (!node) return data;
+
+  const nextAnnotation = {
+    ...(node.annotation ?? {}),
+    borderColor: borderColor ?? undefined,
+  };
+  if (!nextAnnotation.borderColor) {
+    delete nextAnnotation.borderColor;
+  }
+
+  return {
+    ...data,
+    nodes: {
+      ...data.nodes,
+      [nodeId]: {
+        ...node,
+        annotation: Object.keys(nextAnnotation).length ? nextAnnotation : undefined,
+      },
+    },
+  };
+}
+
+function applyNodeDeletion(
+  data: TimelineData,
+  nodeId: number,
+  options: TimelineGraphActionOptions,
+): TimelineData {
+  const node = data.nodes[nodeId];
+  const lockedOpenalexIds = new Set((options.lockedOpenalexIds ?? []).filter(Boolean));
+  if (
+    !node ||
+    nodeId === data.rootId ||
+    lockedOpenalexIds.has(node.paper.openalexId) ||
+    Object.keys(data.nodes).length <= 1
+  ) {
+    return data;
+  }
+
+  const incomingParentIds = Object.entries(data.adjacency)
+    .filter(([, children]) => children.includes(nodeId))
+    .map(([fromId]) => Number(fromId))
+    .filter((fromId) => fromId !== nodeId && data.nodes[fromId]);
+  const outgoingChildIds = (data.adjacency[nodeId] ?? [])
+    .filter((childId) => childId !== nodeId && data.nodes[childId]);
+  const fallbackParentId = incomingParentIds[0] ?? null;
+
+  const nodes = Object.fromEntries(
+    Object.entries(data.nodes)
+      .filter(([id]) => Number(id) !== nodeId)
+      .map(([id, node]) => {
+        const numericId = Number(id);
+        const nextNode: TimelineNode = {
+          ...node,
+          parentId: node.parentId === nodeId ? fallbackParentId : node.parentId,
+        };
+        return [numericId, nextNode];
+      }),
+  );
+
+  const adjacency = Object.fromEntries(
+    Object.entries(data.adjacency)
+      .filter(([fromId]) => Number(fromId) !== nodeId)
+      .map(([fromId, children]) => [
+        Number(fromId),
+        children.filter((childId) => childId !== nodeId && nodes[childId]),
+      ]),
+  );
+
+  Object.keys(nodes).forEach((id) => {
+    const numericId = Number(id);
+    if (!adjacency[numericId]) {
+      adjacency[numericId] = [];
+    }
+  });
+
+  const edgeRelations: Record<string, "influenced" | "inferred"> = Object.fromEntries(
+    Object.entries(data.edgeRelations ?? {}).filter(([key]) => {
+      const [fromId, toId] = key.split("->").map(Number);
+      return fromId !== nodeId && toId !== nodeId && nodes[fromId] && nodes[toId];
+    }),
+  );
+
+  incomingParentIds.forEach((parentId) => {
+    if (!nodes[parentId]) return;
+    const existingChildren = new Set(adjacency[parentId] ?? []);
+    outgoingChildIds.forEach((childId) => {
+      if (!nodes[childId] || childId === parentId) return;
+      existingChildren.add(childId);
+      edgeRelations[edgeKey(parentId, childId)] ??= "inferred";
+    });
+    adjacency[parentId] = [...existingChildren];
+  });
+
+  const remainingIds = Object.keys(nodes).map(Number).sort((a, b) => a - b);
+  const rootId = nodes[data.rootId]
+    ? data.rootId
+    : remainingIds.find((id) => nodes[id].parentId === null) ?? remainingIds[0];
+
+  return {
+    ...data,
+    nodes,
+    adjacency,
+    edgeRelations,
+    rootId,
+    expansions: data.expansions.filter((expansion) => expansion.sourceNodeId !== nodeId),
+  };
+}
+
+function edgeKey(fromId: number, toId: number): string {
+  return `${fromId}->${toId}`;
+}

--- a/frontend/src/lib/timeline-actions.ts
+++ b/frontend/src/lib/timeline-actions.ts
@@ -1,4 +1,5 @@
 import { NodeBorderColor, TimelineData, TimelineGraphAction, TimelineNode } from "./types";
+import { GAP_X, LANE_HEIGHT, NODE_DIMENSIONS, PADDING_X, PADDING_Y } from "./dummy-data";
 
 interface TimelineGraphActionOptions {
   lockedOpenalexIds?: string[];
@@ -117,6 +118,22 @@ function applyNodeDeletion(
     adjacency[parentId] = [...existingChildren];
   });
 
+  const affectedNodeIds = new Set<number>();
+  outgoingChildIds.forEach((childId) => {
+    collectDescendantIds(childId, adjacency, affectedNodeIds);
+  });
+  affectedNodeIds.forEach((affectedNodeId) => {
+    const current = nodes[affectedNodeId];
+    if (!current) return;
+    const generation = computeGenerationFromParents(affectedNodeId, nodes);
+    nodes[affectedNodeId] = {
+      ...current,
+      generation,
+      x: PADDING_X + generation * (NODE_DIMENSIONS.width + GAP_X),
+      y: PADDING_Y + current.lane * LANE_HEIGHT,
+    };
+  });
+
   const remainingIds = Object.keys(nodes).map(Number).sort((a, b) => a - b);
   const rootId = nodes[data.rootId]
     ? data.rootId
@@ -134,4 +151,24 @@ function applyNodeDeletion(
 
 function edgeKey(fromId: number, toId: number): string {
   return `${fromId}->${toId}`;
+}
+
+function collectDescendantIds(
+  nodeId: number,
+  adjacency: Record<number, number[]>,
+  result: Set<number>,
+): void {
+  if (result.has(nodeId)) return;
+  result.add(nodeId);
+  (adjacency[nodeId] ?? []).forEach((childId) => {
+    collectDescendantIds(childId, adjacency, result);
+  });
+}
+
+function computeGenerationFromParents(nodeId: number, nodes: Record<number, TimelineNode>): number {
+  const parentId = nodes[nodeId]?.parentId;
+  if (!parentId || !nodes[parentId]) {
+    return 0;
+  }
+  return nodes[parentId].generation + 1;
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -25,6 +25,23 @@ export interface GraphEdge {
   relation: "influenced" | "inferred";
 }
 
+export type NodeBorderColor = "accent" | "blue" | "green" | "purple" | "amber" | "rose";
+
+export interface TimelineNodeAnnotation {
+  borderColor?: NodeBorderColor;
+}
+
+export type TimelineGraphAction =
+  | {
+      type: "highlight_node";
+      nodeId: number;
+      borderColor: NodeBorderColor | null;
+    }
+  | {
+      type: "delete_node";
+      nodeId: number;
+    };
+
 export interface SeedCandidate {
   openalexId: string;
   title: string;
@@ -136,6 +153,7 @@ export interface TimelineNode {
   parentId: number | null;
   expanded: boolean;
   generation: number;
+  annotation?: TimelineNodeAnnotation;
 }
 
 export interface TimelineData {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added graph controls to highlight a node’s border with selectable colors and to remove the active node (when allowed).
  * Timeline nodes and edges now visually reflect annotation-based border colors.
  * Timeline edits are applied interactively and persisted along with the currently selected seed.

* **Bug Fixes**
  * Prevented deleting protected nodes (root, locked nodes, or when only one node remains).
  * Improved graph integrity after edits, keeping connections and layout consistent (including expansion cleanup).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->