### PR TITLE
sediment: users can now add notes on the graph

### DIFF
--- a/frontend/src/components/TimelineCanvas.tsx
+++ b/frontend/src/components/TimelineCanvas.tsx
@@ -5,11 +5,14 @@ import { motion, AnimatePresence } from "framer-motion";
 import { MarkdownContent } from "./MarkdownContent";
 import { fetchPaperAccess, openChatSession, streamChatAboutPaper } from "@/lib/api";
 import { TIMELINE_MOBILE_BREAKPOINT_PX } from "@/lib/hover-preview";
-import { TimelineData, ChatSuggestion, PaperAccessResponse, TimelineNode, PaperChatStreamEvent, TimelineGraphAction, NodeBorderColor } from "@/lib/types";
+import { TimelineData, ChatSuggestion, PaperAccessResponse, TimelineNode, PaperChatStreamEvent, TimelineGraphAction, NodeBorderColor, TimelineNote } from "@/lib/types";
 import { NODE_BORDER_COLOR_OPTIONS, nodeBorderColorCss } from "@/lib/node-style";
+import { TIMELINE_NOTE_DEFAULT_WIDTH, TIMELINE_NOTE_MIN_HEIGHT } from "@/lib/note-style";
 import { NODE_DIMENSIONS } from "@/lib/dummy-data";
 import { TimelineNodeCard } from "./TimelineNode";
 import { TimelineEdgeLine } from "./TimelineEdge";
+import { TimelineNoteCard } from "./TimelineNote";
+import { TimelineNoteEdgeLine } from "./TimelineNoteEdge";
 import { GlobalChatPanel } from "./GlobalChatPanel";
 
 const DETAIL_PANEL_WIDTH_KEY = "sediment_detail_panel_width";
@@ -112,6 +115,7 @@ export function TimelineCanvas({
   const chatHistoryLoadsRef = useRef<Set<string>>(new Set());
   const activePaperStreamsRef = useRef<Record<number, string>>({});
   const [paperAccessById, setPaperAccessById] = useState<Record<string, PaperAccessState>>({});
+  const noteIdRef = useRef(0);
 
   // Track the latest generation so only new nodes animate
   const latestGenRef = useRef(0);
@@ -233,14 +237,21 @@ export function TimelineCanvas({
   }, [detailPanelWidth]);
 
   const allNodes = Object.values(data.nodes);
+  const allNotes = Object.values(data.notes ?? {});
   const maxX =
-    allNodes.length === 0
+    allNodes.length === 0 && allNotes.length === 0
       ? NODE_DIMENSIONS.width + 120
-      : Math.max(...allNodes.map((n) => n.x + NODE_DIMENSIONS.width)) + 120;
+      : Math.max(
+          ...allNodes.map((n) => n.x + NODE_DIMENSIONS.width),
+          ...allNotes.map((note) => note.x + (note.width ?? TIMELINE_NOTE_DEFAULT_WIDTH)),
+        ) + 120;
   const maxY =
-    allNodes.length === 0
+    allNodes.length === 0 && allNotes.length === 0
       ? NODE_DIMENSIONS.height + 120
-      : Math.max(...allNodes.map((n) => n.y + NODE_DIMENSIONS.height)) + 120;
+      : Math.max(
+          ...allNodes.map((n) => n.y + NODE_DIMENSIONS.height),
+          ...allNotes.map((note) => note.y + (note.height ?? TIMELINE_NOTE_MIN_HEIGHT)),
+        ) + 120;
 
   const applyTransform = useCallback(() => {
     if (gRef.current) {
@@ -621,6 +632,7 @@ export function TimelineCanvas({
   }, [applyTransform, maxX, maxY]);
 
   const nodeArray = Object.values(data.nodes);
+  const noteArray = Object.values(data.notes ?? {});
 
   // Derive edges from adjacency list (single source of truth)
   const edgesForRender = Object.entries(data.adjacency).flatMap(
@@ -633,6 +645,7 @@ export function TimelineCanvas({
       }));
     }
   );
+  const noteEdgesForRender = (data.noteEdges ?? []).filter((edge) => data.notes?.[edge.noteId] && data.nodes[edge.nodeId]);
 
   const activeRelated = new Set<number>();
   if (activeNodeId) {
@@ -828,6 +841,100 @@ export function TimelineCanvas({
     onGraphAction?.({ type: "delete_node", nodeId: activeNodeId });
     setActiveNodeId(null);
   }, [activeNodeId, data.nodes, data.rootId, lockedNodeOpenalexId, onGraphAction, readOnly]);
+
+  const handleAddNoteForActiveNode = useCallback(() => {
+    if (!activeNodeId || !activeNode || readOnly) return;
+    const noteId = `note-${Date.now()}-${++noteIdRef.current}`;
+    const note: TimelineNote = {
+      id: noteId,
+      text: "Add note (markdown supported)",
+      kind: "field_note",
+      x: activeNode.x + NODE_DIMENSIONS.width + 56,
+      y: activeNode.y,
+      width: TIMELINE_NOTE_DEFAULT_WIDTH,
+      color: "paper",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    onGraphAction?.({ type: "add_note", note, connectToNodeId: activeNodeId, relation: "about" });
+  }, [activeNode, activeNodeId, onGraphAction, readOnly]);
+
+  const handleMoveNote = useCallback(
+    (noteId: string, x: number, y: number) => {
+      if (readOnly) return;
+      onGraphAction?.({
+        type: "update_note",
+        noteId,
+        patch: {
+          x: Math.round(x),
+          y: Math.round(y),
+          updatedAt: new Date().toISOString(),
+        },
+      });
+    },
+    [onGraphAction, readOnly],
+  );
+
+  const handleResizeNote = useCallback(
+    (noteId: string, width: number, height: number) => {
+      if (readOnly) return;
+      onGraphAction?.({
+        type: "update_note",
+        noteId,
+        patch: {
+          width: Math.round(width),
+          height: Math.round(height),
+          updatedAt: new Date().toISOString(),
+        },
+      });
+    },
+    [onGraphAction, readOnly],
+  );
+
+  const handleNoteTextChange = useCallback(
+    (noteId: string, text: string) => {
+      if (readOnly) return;
+      onGraphAction?.({ type: "update_note", noteId, patch: { text, updatedAt: new Date().toISOString() } });
+    },
+    [onGraphAction, readOnly],
+  );
+
+  const handleNoteKindChange = useCallback(
+    (noteId: string, kind: TimelineNote["kind"]) => {
+      if (readOnly) return;
+      onGraphAction?.({ type: "update_note", noteId, patch: { kind, updatedAt: new Date().toISOString() } });
+    },
+    [onGraphAction, readOnly],
+  );
+
+  const handleNoteColorChange = useCallback(
+    (noteId: string, color: TimelineNote["color"]) => {
+      if (readOnly) return;
+      onGraphAction?.({ type: "update_note", noteId, patch: { color, updatedAt: new Date().toISOString() } });
+    },
+    [onGraphAction, readOnly],
+  );
+
+  const handleDeleteNote = useCallback(
+    (noteId: string) => {
+      if (readOnly) return;
+      onGraphAction?.({ type: "delete_note", noteId });
+    },
+    [onGraphAction, readOnly],
+  );
+
+  const handleToggleNoteConnection = useCallback(
+    (noteId: string) => {
+      if (!activeNodeId || readOnly) return;
+      const isConnected = (data.noteEdges ?? []).some((edge) => edge.noteId === noteId && edge.nodeId === activeNodeId);
+      onGraphAction?.(
+        isConnected
+          ? { type: "disconnect_note", noteId, nodeId: activeNodeId }
+          : { type: "connect_note", noteId, nodeId: activeNodeId, relation: "about" },
+      );
+    },
+    [activeNodeId, data.noteEdges, onGraphAction, readOnly],
+  );
 
   const hasExistingExpansion = useCallback(
     (sourceNodeId: number, query: string) =>
@@ -1092,6 +1199,21 @@ export function TimelineCanvas({
             );
           })}
 
+          {noteEdgesForRender.map((edge, i) => {
+            const note = data.notes?.[edge.noteId];
+            const node = data.nodes[edge.nodeId];
+            if (!note || !node) return null;
+            return (
+              <TimelineNoteEdgeLine
+                key={`${edge.noteId}-${edge.nodeId}-${i}`}
+                note={note}
+                node={node}
+                edge={edge}
+                index={i}
+              />
+            );
+          })}
+
         </g>
       </svg>
 
@@ -1128,6 +1250,31 @@ export function TimelineCanvas({
               shouldAnimate={node.generation === latestGeneration}
             />
           ))}
+          <AnimatePresence>
+            {noteArray.map((note) => {
+              const connectedNodeCount = (data.noteEdges ?? []).filter((edge) => edge.noteId === note.id).length;
+              const isConnectedToActiveNode = Boolean(
+                activeNodeId && (data.noteEdges ?? []).some((edge) => edge.noteId === note.id && edge.nodeId === activeNodeId),
+              );
+              return (
+                <TimelineNoteCard
+                  key={note.id}
+                  note={note}
+                  connectedNodeCount={connectedNodeCount}
+                  activeNodeId={activeNodeId}
+                  isConnectedToActiveNode={isConnectedToActiveNode}
+                  readOnly={readOnly}
+                  onMove={handleMoveNote}
+                  onResize={handleResizeNote}
+                  onTextChange={handleNoteTextChange}
+                  onKindChange={handleNoteKindChange}
+                  onColorChange={handleNoteColorChange}
+                  onToggleActiveConnection={handleToggleNoteConnection}
+                  onDelete={handleDeleteNote}
+                />
+              );
+            })}
+          </AnimatePresence>
         </div>
       </div>
 
@@ -1474,6 +1621,7 @@ export function TimelineCanvas({
               inset: 0,
               zIndex: 19,
               background: "transparent",
+              pointerEvents: "none",
             }}
           />
         )}
@@ -1811,6 +1959,26 @@ export function TimelineCanvas({
                       {isActiveNodeLocked ? "Seed locked" : "Remove node"}
                     </button>
                   </div>
+
+                  <button
+                    type="button"
+                    onClick={handleAddNoteForActiveNode}
+                    style={{
+                      width: "100%",
+                      background: "color-mix(in srgb, var(--accent-soft) 62%, transparent)",
+                      border: "0.0625rem solid color-mix(in srgb, var(--accent) 36%, var(--border) 64%)",
+                      borderRadius: "0.5rem",
+                      color: "var(--accent)",
+                      cursor: "pointer",
+                      fontSize: "0.6875rem",
+                      fontWeight: 600,
+                      fontFamily: "'DM Sans', sans-serif",
+                      padding: "0.5rem 0.625rem",
+                      textAlign: "left",
+                    }}
+                  >
+                    Add connected note
+                  </button>
                 </div>
               )}
 

--- a/frontend/src/components/TimelineCanvas.tsx
+++ b/frontend/src/components/TimelineCanvas.tsx
@@ -646,6 +646,14 @@ export function TimelineCanvas({
     }
   );
   const noteEdgesForRender = (data.noteEdges ?? []).filter((edge) => data.notes?.[edge.noteId] && data.nodes[edge.nodeId]);
+  const noteConnectionCounts = new Map<string, number>();
+  const noteIdsConnectedToActiveNode = new Set<string>();
+  noteEdgesForRender.forEach((edge) => {
+    noteConnectionCounts.set(edge.noteId, (noteConnectionCounts.get(edge.noteId) ?? 0) + 1);
+    if (activeNodeId && edge.nodeId === activeNodeId) {
+      noteIdsConnectedToActiveNode.add(edge.noteId);
+    }
+  });
 
   const activeRelated = new Set<number>();
   if (activeNodeId) {
@@ -853,6 +861,7 @@ export function TimelineCanvas({
       x: activeNode.x + NODE_DIMENSIONS.width + 56,
       y: activeNode.y,
       width: TIMELINE_NOTE_DEFAULT_WIDTH,
+      height: TIMELINE_NOTE_MIN_HEIGHT,
       color: "paper",
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
@@ -1253,17 +1262,13 @@ export function TimelineCanvas({
           ))}
           <AnimatePresence>
             {noteArray.map((note) => {
-              const connectedNodeCount = (data.noteEdges ?? []).filter((edge) => edge.noteId === note.id).length;
-              const isConnectedToActiveNode = Boolean(
-                activeNodeId && (data.noteEdges ?? []).some((edge) => edge.noteId === note.id && edge.nodeId === activeNodeId),
-              );
               return (
                 <TimelineNoteCard
                   key={note.id}
                   note={note}
-                  connectedNodeCount={connectedNodeCount}
+                  connectedNodeCount={noteConnectionCounts.get(note.id) ?? 0}
                   activeNodeId={activeNodeId}
-                  isConnectedToActiveNode={isConnectedToActiveNode}
+                  isConnectedToActiveNode={noteIdsConnectedToActiveNode.has(note.id)}
                   readOnly={readOnly}
                   onMove={handleMoveNote}
                   onResize={handleResizeNote}
@@ -1616,7 +1621,6 @@ export function TimelineCanvas({
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             transition={{ duration: 0.2 }}
-            onClick={() => setActiveNodeId(null)}
             style={{
               position: "absolute",
               inset: 0,

--- a/frontend/src/components/TimelineNote.tsx
+++ b/frontend/src/components/TimelineNote.tsx
@@ -1,0 +1,513 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { motion } from "framer-motion";
+import { TimelineNote } from "@/lib/types";
+import { NOTE_COLOR_OPTIONS, NOTE_KIND_OPTIONS, TIMELINE_NOTE_DEFAULT_WIDTH, TIMELINE_NOTE_MIN_HEIGHT, noteColorStyle, noteKindLabel } from "@/lib/note-style";
+import { MarkdownContent } from "./MarkdownContent";
+
+interface TimelineNoteCardProps {
+  note: TimelineNote;
+  connectedNodeCount: number;
+  activeNodeId?: number | null;
+  isConnectedToActiveNode?: boolean;
+  readOnly?: boolean;
+  onMove?: (noteId: string, x: number, y: number) => void;
+  onResize?: (noteId: string, width: number, height: number) => void;
+  onTextChange?: (noteId: string, text: string) => void;
+  onKindChange?: (noteId: string, kind: TimelineNote["kind"]) => void;
+  onColorChange?: (noteId: string, color: TimelineNote["color"]) => void;
+  onToggleActiveConnection?: (noteId: string) => void;
+  onDelete?: (noteId: string) => void;
+}
+
+export function TimelineNoteCard({
+  note,
+  connectedNodeCount,
+  activeNodeId,
+  isConnectedToActiveNode = false,
+  readOnly = false,
+  onMove,
+  onResize,
+  onTextChange,
+  onKindChange,
+  onColorChange,
+  onToggleActiveConnection,
+  onDelete,
+}: TimelineNoteCardProps) {
+  const width = note.width ?? TIMELINE_NOTE_DEFAULT_WIDTH;
+  const height = note.height ?? TIMELINE_NOTE_MIN_HEIGHT;
+  const colorStyle = noteColorStyle(note.color);
+  const cardRef = useRef<HTMLDivElement>(null);
+  const dragStartRef = useRef<{ pointerId: number; clientX: number; clientY: number; x: number; y: number } | null>(null);
+  const resizeStartRef = useRef<{ pointerId: number; clientX: number; clientY: number; width: number; height: number } | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [isResizing, setIsResizing] = useState(false);
+  const [kindMenuOpen, setKindMenuOpen] = useState(false);
+  const [isEditingText, setIsEditingText] = useState(false);
+
+  useEffect(() => {
+    if (!kindMenuOpen) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (target instanceof Node && cardRef.current?.contains(target)) return;
+      setKindMenuOpen(false);
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setKindMenuOpen(false);
+      }
+    };
+
+    window.addEventListener("pointerdown", handlePointerDown);
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("pointerdown", handlePointerDown);
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [kindMenuOpen]);
+
+  const handlePointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (readOnly || event.button !== 0) return;
+      const target = event.target;
+      if (target instanceof Element && target.closest("[data-note-control='true']")) return;
+      event.preventDefault();
+      event.stopPropagation();
+      dragStartRef.current = {
+        pointerId: event.pointerId,
+        clientX: event.clientX,
+        clientY: event.clientY,
+        x: note.x,
+        y: note.y,
+      };
+      setIsDragging(true);
+      event.currentTarget.setPointerCapture(event.pointerId);
+    },
+    [note.x, note.y, readOnly],
+  );
+
+  const handlePointerMove = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      const start = dragStartRef.current;
+      if (!start || start.pointerId !== event.pointerId || readOnly) return;
+      event.preventDefault();
+      event.stopPropagation();
+      onMove?.(note.id, start.x + event.clientX - start.clientX, start.y + event.clientY - start.clientY);
+    },
+    [note.id, onMove, readOnly],
+  );
+
+  const finishDrag = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    const start = dragStartRef.current;
+    if (!start || start.pointerId !== event.pointerId) return;
+    event.preventDefault();
+    event.stopPropagation();
+    dragStartRef.current = null;
+    setIsDragging(false);
+  }, []);
+
+  const handleResizePointerDown = useCallback(
+    (event: React.PointerEvent<HTMLButtonElement>) => {
+      if (readOnly || event.button !== 0) return;
+      event.preventDefault();
+      event.stopPropagation();
+      resizeStartRef.current = {
+        pointerId: event.pointerId,
+        clientX: event.clientX,
+        clientY: event.clientY,
+        width,
+        height,
+      };
+      setIsResizing(true);
+      event.currentTarget.setPointerCapture(event.pointerId);
+    },
+    [height, readOnly, width],
+  );
+
+  const handleResizePointerMove = useCallback(
+    (event: React.PointerEvent<HTMLButtonElement>) => {
+      const start = resizeStartRef.current;
+      if (!start || start.pointerId !== event.pointerId || readOnly) return;
+      event.preventDefault();
+      event.stopPropagation();
+      const nextWidth = Math.max(180, start.width + event.clientX - start.clientX);
+      const nextHeight = Math.max(TIMELINE_NOTE_MIN_HEIGHT, start.height + event.clientY - start.clientY);
+      onResize?.(note.id, nextWidth, nextHeight);
+    },
+    [note.id, onResize, readOnly],
+  );
+
+  const finishResize = useCallback((event: React.PointerEvent<HTMLButtonElement>) => {
+    const start = resizeStartRef.current;
+    if (!start || start.pointerId !== event.pointerId) return;
+    event.preventDefault();
+    event.stopPropagation();
+    resizeStartRef.current = null;
+    setIsResizing(false);
+  }, []);
+
+  return (
+    <motion.div
+      ref={cardRef}
+      data-canvas-ui="true"
+      initial={{ opacity: 0, scale: 0.96, y: 8 }}
+      animate={{ opacity: 1, scale: 1, y: 0 }}
+      exit={{ opacity: 0, scale: 0.96, y: 8 }}
+      transition={{ duration: 0.2, ease: [0.16, 1, 0.3, 1] }}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={finishDrag}
+      onPointerCancel={finishDrag}
+      style={{
+        position: "absolute",
+        left: note.x,
+        top: note.y,
+        width,
+        height: readOnly && !note.height ? "auto" : height,
+        minHeight: readOnly ? undefined : TIMELINE_NOTE_MIN_HEIGHT,
+        cursor: readOnly ? "default" : isDragging ? "grabbing" : "grab",
+        touchAction: "none",
+        zIndex: 4,
+      }}
+    >
+      <div
+        style={{
+          position: "relative",
+          height: readOnly && !note.height ? "auto" : height,
+          minHeight: readOnly ? undefined : TIMELINE_NOTE_MIN_HEIGHT,
+          borderRadius: "0.95rem",
+          border: `0.0625rem solid ${colorStyle.border}`,
+          background: colorStyle.background,
+          boxShadow: isDragging
+            ? "0 1.125rem 2.5rem rgba(0,0,0,0.24), 0 0 0 0.1875rem var(--accent-soft)"
+            : "0 0.75rem 2rem rgba(0,0,0,0.18), inset 0 0.0625rem 0 rgba(255,255,255,0.05)",
+          overflow: "visible",
+          userSelect: isDragging ? "none" : "auto",
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            background:
+              "radial-gradient(circle at 16% 10%, rgba(255,255,255,0.08), transparent 34%), linear-gradient(135deg, rgba(255,255,255,0.035), transparent 42%)",
+            pointerEvents: "none",
+          }}
+        />
+
+        <div
+          style={{
+            position: "relative",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: "0.5rem",
+            padding: "0.625rem 0.75rem 0",
+          }}
+        >
+          {readOnly ? (
+            <span
+              style={{
+                fontSize: "0.5625rem",
+                fontFamily: "'JetBrains Mono', monospace",
+                letterSpacing: "0.12em",
+                textTransform: "uppercase",
+                color: colorStyle.accent,
+              }}
+            >
+              {noteKindLabel(note.kind)}
+            </span>
+          ) : (
+            <div
+              data-note-control="true"
+              style={{
+                position: "relative",
+                minWidth: 0,
+              }}
+              onPointerDown={(event) => event.stopPropagation()}
+            >
+              <button
+                type="button"
+                onClick={() => setKindMenuOpen((open) => !open)}
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: "0.35rem",
+                  maxWidth: "9.5rem",
+                  border: "none",
+                  outline: "none",
+                  background: "transparent",
+                  color: colorStyle.accent,
+                  cursor: "pointer",
+                  fontSize: "0.5625rem",
+                  fontFamily: "'JetBrains Mono', monospace",
+                  letterSpacing: "0.12em",
+                  textTransform: "uppercase",
+                  padding: 0,
+                }}
+              >
+                <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                  {noteKindLabel(note.kind)}
+                </span>
+                <svg width="8" height="8" viewBox="0 0 8 8" fill="none" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0, opacity: 0.8 }}>
+                  <path d="M2 3l2 2 2-2" />
+                </svg>
+              </button>
+
+              {kindMenuOpen && (
+                <div
+                  role="menu"
+                  style={{
+                    position: "absolute",
+                    top: "calc(100% + 0.45rem)",
+                    left: "-0.35rem",
+                    width: "11.25rem",
+                    padding: "0.35rem",
+                    borderRadius: "0.75rem",
+                    border: "0.0625rem solid var(--border-hover)",
+                    background: "color-mix(in srgb, var(--bg-primary) 92%, #1e1510 8%)",
+                    boxShadow: "0 1rem 2.25rem rgba(0,0,0,0.32)",
+                    zIndex: 30,
+                  }}
+                >
+                  {NOTE_KIND_OPTIONS.map((kind) => {
+                    const selected = (note.kind ?? "field_note") === kind.key;
+                    return (
+                      <button
+                        key={kind.key}
+                        type="button"
+                        role="menuitemradio"
+                        aria-checked={selected}
+                        onClick={() => {
+                          onKindChange?.(note.id, kind.key);
+                          setKindMenuOpen(false);
+                        }}
+                        style={{
+                          width: "100%",
+                          display: "grid",
+                          gridTemplateColumns: "1rem 1fr",
+                          alignItems: "center",
+                          gap: "0.5rem",
+                          border: "none",
+                          borderRadius: "0.5rem",
+                          background: selected ? "var(--accent-soft)" : "transparent",
+                          color: selected ? "var(--accent)" : "var(--text-secondary)",
+                          cursor: "pointer",
+                          fontSize: "0.625rem",
+                          fontFamily: "'JetBrains Mono', monospace",
+                          letterSpacing: "0.08em",
+                          textTransform: "uppercase",
+                          textAlign: "left",
+                          padding: "0.5rem 0.55rem",
+                        }}
+                      >
+                        <span style={{ width: "1rem", display: "inline-flex", justifyContent: "center" }}>
+                          {selected ? "✓" : ""}
+                        </span>
+                        <span>{kind.shortLabel}</span>
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          )}
+
+          <span
+            title={`${connectedNodeCount} connected node${connectedNodeCount === 1 ? "" : "s"}`}
+            style={{
+              fontSize: "0.5625rem",
+              fontFamily: "'JetBrains Mono', monospace",
+              color: "var(--text-tertiary)",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {connectedNodeCount} link{connectedNodeCount === 1 ? "" : "s"}
+          </span>
+        </div>
+
+        {!readOnly && isEditingText ? (
+          <textarea
+            data-note-control="true"
+            value={note.text}
+            onChange={(event) => onTextChange?.(note.id, event.currentTarget.value)}
+            onPointerDown={(event) => event.stopPropagation()}
+            onFocus={() => setIsEditingText(true)}
+            onBlur={() => setIsEditingText(false)}
+            autoFocus
+            style={{
+              position: "relative",
+              width: "100%",
+              flex: 1,
+              minHeight: 0,
+              resize: "none",
+              border: "none",
+              outline: "none",
+              background: "transparent",
+              color: "var(--text-primary)",
+              fontFamily: "'Instrument Serif', Georgia, serif",
+              fontSize: "1.0625rem",
+              lineHeight: 1.32,
+              letterSpacing: "-0.01em",
+              padding: "0.5rem 0.75rem",
+              cursor: "text",
+            }}
+          />
+        ) : (
+          <button
+            data-note-control="true"
+            type="button"
+            disabled={readOnly}
+            onClick={() => {
+              if (!readOnly) {
+                setIsEditingText(true);
+              }
+            }}
+            onPointerDown={(event) => event.stopPropagation()}
+            style={{
+              position: "relative",
+              width: "100%",
+              flex: readOnly && !note.height ? undefined : 1,
+              minHeight: 0,
+              border: "none",
+              background: "transparent",
+              textAlign: "left",
+              padding: "0.5rem 0.75rem 0.85rem",
+              overflow: "auto",
+              cursor: readOnly ? "default" : "text",
+            }}
+          >
+            <MarkdownContent
+              style={{
+                color: "var(--text-primary)",
+                fontFamily: "'Instrument Serif', Georgia, serif",
+                fontSize: "1.0625rem",
+                lineHeight: 1.32,
+                letterSpacing: "-0.01em",
+                overflowWrap: "break-word",
+              }}
+            >
+              {note.text || "Add note (markdown supported)"}
+            </MarkdownContent>
+          </button>
+        )}
+
+        {!readOnly && (
+          <div
+            data-note-control="true"
+            style={{
+              position: "relative",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              gap: "0.5rem",
+              padding: "0 0.625rem 0.625rem",
+            }}
+            onPointerDown={(event) => event.stopPropagation()}
+          >
+            <div style={{ display: "flex", gap: "0.25rem" }}>
+              {NOTE_COLOR_OPTIONS.map((color) => {
+                const selected = (note.color ?? "paper") === color.key;
+                return (
+                  <button
+                    key={color.key}
+                    type="button"
+                    title={`Set note ${color.label.toLowerCase()}`}
+                    aria-label={`Set note ${color.label.toLowerCase()}`}
+                    onClick={() => onColorChange?.(note.id, color.key)}
+                    style={{
+                      width: "1rem",
+                      height: "1rem",
+                      borderRadius: "999px",
+                      border: `0.09375rem solid ${selected ? "var(--text-primary)" : "var(--border)"}`,
+                      background: color.accent,
+                      cursor: "pointer",
+                      opacity: selected ? 1 : 0.72,
+                    }}
+                  />
+                );
+              })}
+            </div>
+
+            <button
+              type="button"
+              onClick={() => onDelete?.(note.id)}
+              style={{
+                background: "transparent",
+                border: "none",
+                color: "var(--text-tertiary)",
+                cursor: "pointer",
+                fontSize: "0.625rem",
+                fontFamily: "'JetBrains Mono', monospace",
+                letterSpacing: "0.04em",
+                padding: "0.125rem",
+              }}
+            >
+              Delete
+            </button>
+          </div>
+        )}
+
+        {!readOnly && activeNodeId && (
+          <button
+            data-note-control="true"
+            type="button"
+            onPointerDown={(event) => event.stopPropagation()}
+            onClick={() => onToggleActiveConnection?.(note.id)}
+            style={{
+              position: "relative",
+              width: "calc(100% - 1.25rem)",
+              margin: "0 0.625rem 0.625rem",
+              border: `0.0625rem solid ${isConnectedToActiveNode ? colorStyle.accent : "var(--border)"}`,
+              borderRadius: "0.5rem",
+              background: isConnectedToActiveNode ? "color-mix(in srgb, var(--accent-soft) 72%, transparent)" : "var(--bg-primary)",
+              color: isConnectedToActiveNode ? "var(--accent)" : "var(--text-secondary)",
+              cursor: "pointer",
+              fontSize: "0.625rem",
+              fontFamily: "'JetBrains Mono', monospace",
+              letterSpacing: "0.04em",
+              padding: "0.375rem 0.5rem",
+              textTransform: "uppercase",
+            }}
+          >
+            {isConnectedToActiveNode ? "Unlink selected paper" : "Link selected paper"}
+          </button>
+        )}
+
+        {!readOnly && (
+          <button
+            data-note-control="true"
+            type="button"
+            aria-label="Resize note"
+            title="Resize note"
+            onPointerDown={handleResizePointerDown}
+            onPointerMove={handleResizePointerMove}
+            onPointerUp={finishResize}
+            onPointerCancel={finishResize}
+            style={{
+              position: "absolute",
+              right: "0.5rem",
+              bottom: "0.5rem",
+              width: "1rem",
+              height: "1rem",
+              border: "none",
+              background: "transparent",
+              cursor: isResizing ? "nwse-resize" : "nwse-resize",
+              padding: 0,
+              color: "var(--text-tertiary)",
+            }}
+          >
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
+              <path d="M6 13L13 6" />
+              <path d="M10 13L13 10" />
+            </svg>
+          </button>
+        )}
+      </div>
+    </motion.div>
+  );
+}

--- a/frontend/src/components/TimelineNoteEdge.tsx
+++ b/frontend/src/components/TimelineNoteEdge.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { TimelineNode, TimelineNote, TimelineNoteEdge } from "@/lib/types";
+import { NODE_DIMENSIONS } from "@/lib/dummy-data";
+import { TIMELINE_NOTE_DEFAULT_WIDTH, TIMELINE_NOTE_MIN_HEIGHT, noteColorStyle } from "@/lib/note-style";
+
+interface TimelineNoteEdgeLineProps {
+  note: TimelineNote;
+  node: TimelineNode;
+  edge: TimelineNoteEdge;
+  index: number;
+}
+
+export function TimelineNoteEdgeLine({ note, node, edge, index }: TimelineNoteEdgeLineProps) {
+  const noteWidth = note.width ?? TIMELINE_NOTE_DEFAULT_WIDTH;
+  const noteHeight = note.height ?? TIMELINE_NOTE_MIN_HEIGHT;
+  const colorStyle = noteColorStyle(note.color);
+
+  const noteCenterX = note.x + noteWidth / 2;
+  const noteCenterY = note.y + noteHeight / 2;
+  const nodeCenterX = node.x + NODE_DIMENSIONS.width / 2;
+  const nodeCenterY = node.y + NODE_DIMENSIONS.height / 2;
+  const noteAnchorX = noteCenterX < nodeCenterX ? note.x + noteWidth : note.x;
+  const nodeAnchorX = noteCenterX < nodeCenterX ? node.x : node.x + NODE_DIMENSIONS.width;
+  const midX = (noteAnchorX + nodeAnchorX) / 2;
+  const path = `M ${noteAnchorX} ${noteCenterY} C ${midX} ${noteCenterY}, ${midX} ${nodeCenterY}, ${nodeAnchorX} ${nodeCenterY}`;
+
+  return (
+    <g>
+      <motion.path
+        d={path}
+        fill="none"
+        stroke={colorStyle.accent}
+        strokeWidth={1.35}
+        strokeLinecap="round"
+        strokeDasharray={edge.relation === "question" ? "5 4" : "2 5"}
+        initial={{ pathLength: 0, opacity: 0 }}
+        animate={{ pathLength: 1, opacity: 0.58 }}
+        transition={{
+          pathLength: {
+            duration: 0.45,
+            delay: index * 0.04,
+            ease: [0.16, 1, 0.3, 1],
+          },
+          opacity: { duration: 0.2, delay: index * 0.04 },
+        }}
+      />
+      <circle cx={nodeAnchorX} cy={nodeCenterY} r="3" fill={colorStyle.accent} opacity="0.72" />
+    </g>
+  );
+}

--- a/frontend/src/lib/note-style.ts
+++ b/frontend/src/lib/note-style.ts
@@ -1,0 +1,68 @@
+import { TimelineNote, TimelineNoteKind } from "./types";
+
+export const TIMELINE_NOTE_DEFAULT_WIDTH = 220;
+export const TIMELINE_NOTE_MIN_HEIGHT = 132;
+
+export const NOTE_COLOR_OPTIONS: Array<{
+  key: NonNullable<TimelineNote["color"]>;
+  label: string;
+  background: string;
+  border: string;
+  accent: string;
+}> = [
+  {
+    key: "paper",
+    label: "Paper",
+    background: "color-mix(in srgb, var(--bg-secondary) 88%, #f4ead7 12%)",
+    border: "color-mix(in srgb, var(--border) 72%, #d7bd8a 28%)",
+    accent: "var(--accent)",
+  },
+  {
+    key: "amber",
+    label: "Amber",
+    background: "color-mix(in srgb, #f6d68b 18%, var(--bg-secondary) 82%)",
+    border: "color-mix(in srgb, #f59e0b 38%, var(--border) 62%)",
+    accent: "#f59e0b",
+  },
+  {
+    key: "blue",
+    label: "Blue",
+    background: "color-mix(in srgb, #60a5fa 14%, var(--bg-secondary) 86%)",
+    border: "color-mix(in srgb, #60a5fa 34%, var(--border) 66%)",
+    accent: "#60a5fa",
+  },
+  {
+    key: "green",
+    label: "Green",
+    background: "color-mix(in srgb, #34d399 13%, var(--bg-secondary) 87%)",
+    border: "color-mix(in srgb, #34d399 32%, var(--border) 68%)",
+    accent: "#34d399",
+  },
+  {
+    key: "rose",
+    label: "Rose",
+    background: "color-mix(in srgb, #fb7185 13%, var(--bg-secondary) 87%)",
+    border: "color-mix(in srgb, #fb7185 34%, var(--border) 66%)",
+    accent: "#fb7185",
+  },
+];
+
+export const NOTE_KIND_OPTIONS: Array<{
+  key: TimelineNoteKind;
+  label: string;
+  shortLabel: string;
+}> = [
+  { key: "field_note", label: "Field note", shortLabel: "FIELD NOTE" },
+  { key: "question", label: "Question", shortLabel: "QUESTION" },
+  { key: "insight", label: "Insight", shortLabel: "INSIGHT" },
+  { key: "todo", label: "Todo", shortLabel: "TODO" },
+  { key: "contradiction", label: "Contradiction", shortLabel: "CONTRADICTION" },
+];
+
+export function noteColorStyle(color: TimelineNote["color"] = "paper") {
+  return NOTE_COLOR_OPTIONS.find((option) => option.key === color) ?? NOTE_COLOR_OPTIONS[0];
+}
+
+export function noteKindLabel(kind: TimelineNote["kind"] = "field_note") {
+  return NOTE_KIND_OPTIONS.find((option) => option.key === kind)?.shortLabel ?? NOTE_KIND_OPTIONS[0].shortLabel;
+}

--- a/frontend/src/lib/timeline-actions.ts
+++ b/frontend/src/lib/timeline-actions.ts
@@ -183,7 +183,11 @@ function applyNoteAddition(
     },
   };
   const noteEdges = [...(data.noteEdges ?? [])];
-  if (action.connectToNodeId && data.nodes[action.connectToNodeId]) {
+  if (
+    action.connectToNodeId !== null &&
+    action.connectToNodeId !== undefined &&
+    data.nodes[action.connectToNodeId]
+  ) {
     noteEdges.push({
       noteId: action.note.id,
       nodeId: action.connectToNodeId,

--- a/frontend/src/lib/timeline-actions.ts
+++ b/frontend/src/lib/timeline-actions.ts
@@ -15,6 +15,21 @@ export function applyTimelineGraphAction(
   if (action.type === "delete_node") {
     return applyNodeDeletion(data, action.nodeId, options);
   }
+  if (action.type === "add_note") {
+    return applyNoteAddition(data, action);
+  }
+  if (action.type === "update_note") {
+    return applyNoteUpdate(data, action.noteId, action.patch);
+  }
+  if (action.type === "delete_note") {
+    return applyNoteDeletion(data, action.noteId);
+  }
+  if (action.type === "connect_note") {
+    return applyNoteConnection(data, action.noteId, action.nodeId, action.relation);
+  }
+  if (action.type === "disconnect_note") {
+    return applyNoteDisconnection(data, action.noteId, action.nodeId);
+  }
   return data;
 }
 
@@ -127,6 +142,7 @@ function applyNodeDeletion(
     nodes,
     adjacency,
     edgeRelations,
+    noteEdges: (data.noteEdges ?? []).filter((edge) => edge.nodeId !== nodeId),
     rootId,
     expansions: data.expansions.filter((expansion) => expansion.sourceNodeId !== nodeId),
   };
@@ -134,4 +150,106 @@ function applyNodeDeletion(
 
 function edgeKey(fromId: number, toId: number): string {
   return `${fromId}->${toId}`;
+}
+
+function applyNoteAddition(
+  data: TimelineData,
+  action: Extract<TimelineGraphAction, { type: "add_note" }>,
+): TimelineData {
+  if (!action.note.id) return data;
+
+  const notes = {
+    ...(data.notes ?? {}),
+    [action.note.id]: {
+      ...action.note,
+      text: action.note.text || "New research note",
+    },
+  };
+  const noteEdges = [...(data.noteEdges ?? [])];
+  if (action.connectToNodeId && data.nodes[action.connectToNodeId]) {
+    noteEdges.push({
+      noteId: action.note.id,
+      nodeId: action.connectToNodeId,
+      relation: action.relation ?? "about",
+    });
+  }
+
+  return dedupeNoteEdges({
+    ...data,
+    notes,
+    noteEdges,
+  });
+}
+
+function applyNoteUpdate(
+  data: TimelineData,
+  noteId: string,
+  patch: Partial<NonNullable<TimelineData["notes"]>[string]>,
+): TimelineData {
+  const note = data.notes?.[noteId];
+  if (!note) return data;
+
+  return {
+    ...data,
+    notes: {
+      ...(data.notes ?? {}),
+      [noteId]: {
+        ...note,
+        ...patch,
+        id: noteId,
+      },
+    },
+  };
+}
+
+function applyNoteDeletion(data: TimelineData, noteId: string): TimelineData {
+  if (!data.notes?.[noteId]) return data;
+
+  const notes = { ...data.notes };
+  delete notes[noteId];
+
+  return {
+    ...data,
+    notes: Object.keys(notes).length ? notes : undefined,
+    noteEdges: (data.noteEdges ?? []).filter((edge) => edge.noteId !== noteId),
+  };
+}
+
+function applyNoteConnection(
+  data: TimelineData,
+  noteId: string,
+  nodeId: number,
+  relation: Extract<TimelineGraphAction, { type: "connect_note" }>["relation"],
+): TimelineData {
+  if (!data.notes?.[noteId] || !data.nodes[nodeId]) return data;
+
+  return dedupeNoteEdges({
+    ...data,
+    noteEdges: [
+      ...(data.noteEdges ?? []),
+      { noteId, nodeId, relation: relation ?? "about" },
+    ],
+  });
+}
+
+function applyNoteDisconnection(data: TimelineData, noteId: string, nodeId: number): TimelineData {
+  if (!data.notes?.[noteId]) return data;
+
+  return {
+    ...data,
+    noteEdges: (data.noteEdges ?? []).filter((edge) => edge.noteId !== noteId || edge.nodeId !== nodeId),
+  };
+}
+
+function dedupeNoteEdges(data: TimelineData): TimelineData {
+  const seen = new Set<string>();
+  return {
+    ...data,
+    noteEdges: (data.noteEdges ?? []).filter((edge) => {
+      const key = `${edge.noteId}->${edge.nodeId}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return Boolean(data.notes?.[edge.noteId] && data.nodes[edge.nodeId]);
+    }),
+  };
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -31,6 +31,28 @@ export interface TimelineNodeAnnotation {
   borderColor?: NodeBorderColor;
 }
 
+export type TimelineNoteRelation = "about" | "question" | "insight" | "todo" | "contradiction";
+export type TimelineNoteKind = "field_note" | "question" | "insight" | "todo" | "contradiction";
+
+export interface TimelineNote {
+  id: string;
+  kind?: TimelineNoteKind;
+  text: string;
+  x: number;
+  y: number;
+  width?: number;
+  height?: number;
+  color?: "paper" | "amber" | "blue" | "green" | "rose";
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface TimelineNoteEdge {
+  noteId: string;
+  nodeId: number;
+  relation?: TimelineNoteRelation;
+}
+
 export type TimelineGraphAction =
   | {
       type: "highlight_node";
@@ -39,6 +61,32 @@ export type TimelineGraphAction =
     }
   | {
       type: "delete_node";
+      nodeId: number;
+    }
+  | {
+      type: "add_note";
+      note: TimelineNote;
+      connectToNodeId?: number | null;
+      relation?: TimelineNoteRelation;
+    }
+  | {
+      type: "update_note";
+      noteId: string;
+      patch: Partial<Omit<TimelineNote, "id">>;
+    }
+  | {
+      type: "delete_note";
+      noteId: string;
+    }
+  | {
+      type: "connect_note";
+      noteId: string;
+      nodeId: number;
+      relation?: TimelineNoteRelation;
+    }
+  | {
+      type: "disconnect_note";
+      noteId: string;
       nodeId: number;
     };
 
@@ -160,6 +208,8 @@ export interface TimelineData {
   nodes: Record<number, TimelineNode>;
   adjacency: Record<number, number[]>;
   edgeRelations?: Record<string, GraphEdge["relation"]>;
+  notes?: Record<string, TimelineNote>;
+  noteEdges?: TimelineNoteEdge[];
   lanes: number;
   rootId: number;
   expansions: Expansion[];


### PR DESCRIPTION
<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/bb0b5dcf-93aa-40c7-b722-51a499521c24" />

You can now add notes and link them to different nodes, with markdown support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added timeline notes to the canvas, including creating, moving, resizing, editing (Markdown), choosing kind/color, and deleting.
  * Added note-to-node connections with visible connector lines and a new “Add connected note” action in graph controls.
  * Improved canvas fit-to-view/pan behavior so note cards are included in navigation bounds.
* **Bug Fixes**
  * Prevented duplicate or invalid note connections when notes or nodes are removed.
  * Updated active-node panel interactions to avoid blocking canvas input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->