### PR TITLE
sediment: #89 ui regressions

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -189,6 +189,97 @@ body {
 }
 
 @media (min-width: 40.0625rem) {
+  .app-header-shared {
+    position: absolute !important;
+    top: 0.75rem;
+    left: 50%;
+    transform: translateX(-50%) !important;
+    width: max-content !important;
+    max-width: calc(100vw - 2rem);
+    min-height: 0 !important;
+    padding: 0.3125rem 0.375rem !important;
+    border: 0.0625rem solid color-mix(in srgb, var(--border) 72%, transparent) !important;
+    border-radius: 0.875rem;
+    background: color-mix(in srgb, var(--bg-primary) 88%, transparent) !important;
+    box-shadow: 0 0.625rem 1.75rem rgba(0, 0, 0, 0.12) !important;
+    backdrop-filter: blur(16px);
+    justify-content: flex-start !important;
+  }
+
+  .app-header-shared .app-header-brand {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    height: 2rem;
+    padding: 0 0.625rem;
+  }
+
+  .app-header-shared .app-header-brand svg {
+    width: 1rem;
+    height: 1rem;
+  }
+
+  .app-header-shared .app-header-brand span {
+    color: var(--text-secondary);
+    font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif !important;
+    font-size: 0.75rem !important;
+    font-weight: 500 !important;
+    letter-spacing: -0.01em !important;
+  }
+
+  .app-header-shared .app-header-query {
+    position: static !important;
+    transform: none !important;
+    display: inline-block;
+    min-width: 0;
+    max-width: min(22vw, 20rem) !important;
+    padding-bottom: 0.0625rem;
+    overflow: hidden;
+    border-bottom: 0.0625rem solid color-mix(in srgb, var(--text-secondary) 48%, transparent);
+    color: var(--text-secondary);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.75rem !important;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    pointer-events: none;
+  }
+
+  .app-header-shared .app-header-actions {
+    gap: 0.125rem !important;
+  }
+
+  .app-header-shared .desktop-only {
+    display: contents !important;
+  }
+
+  .app-header-shared .app-header-shared-action {
+    display: flex !important;
+    align-items: center;
+    justify-content: center;
+    min-width: 2rem;
+    height: 2rem;
+    box-sizing: border-box;
+    border: none !important;
+    background: transparent !important;
+    color: var(--text-secondary) !important;
+    text-decoration: none;
+  }
+
+  .app-header-shared .app-header-shared-action:hover {
+    background: var(--bg-tertiary) !important;
+    color: var(--text-primary) !important;
+  }
+
+  .app-header-shared .app-header-shared-icon-action,
+  .app-header-shared .app-header-shared-compact-toggle {
+    width: 2rem !important;
+    min-width: 2rem;
+    padding: 0 !important;
+    gap: 0 !important;
+  }
+
   .app-header-graph {
     position: absolute !important;
     inset: 0 0 auto !important;
@@ -301,6 +392,79 @@ body {
     gap: 0 !important;
     border: none !important;
   }
+}
+
+.app-header-shared.app-header-compact {
+  gap: 0.125rem !important;
+}
+
+.app-header-shared {
+  transition: padding 200ms ease, gap 200ms ease;
+}
+
+.app-header-shared .app-header-brand span {
+  display: inline-block;
+  max-width: 7rem;
+  overflow: hidden;
+  white-space: nowrap;
+  transition: max-width 200ms ease, opacity 150ms ease;
+}
+
+.app-header-shared .app-header-query {
+  transition: max-width 200ms ease, opacity 150ms ease, padding 200ms ease, border-color 150ms ease;
+}
+
+.app-header-shared.app-header-compact .app-header-actions {
+  padding: 0 !important;
+}
+
+.app-header-shared.app-header-compact .app-header-brand {
+  gap: 0;
+  padding-inline: 0.5rem;
+}
+
+.app-header-shared.app-header-compact .app-header-brand span {
+  max-width: 0;
+  overflow: hidden;
+  opacity: 0;
+}
+
+.app-header-shared.app-header-compact .app-header-query {
+  max-width: 0 !important;
+  padding-bottom: 0;
+  border-bottom-color: transparent;
+  opacity: 0;
+}
+
+.app-header-shared.app-header-compact .app-header-shared-session-theme .app-header-action-label {
+  max-width: 7rem;
+  opacity: 1;
+}
+
+.app-header-compact .app-header-graph-session-theme .app-header-action-label {
+  max-width: 7rem;
+  opacity: 1;
+}
+
+.app-header-compact .app-header-mobile-menu-theme .app-header-action-label {
+  max-width: 7rem;
+  opacity: 1;
+}
+
+.app-header-mobile-menu-theme {
+  box-sizing: border-box;
+  min-height: 2.5rem;
+  height: auto !important;
+  padding: 0.625rem 0.5rem !important;
+  color: var(--text-primary) !important;
+  font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif !important;
+  font-size: 0.875rem !important;
+  font-weight: 500 !important;
+}
+
+.app-header-mobile-menu-theme svg {
+  width: 0.9375rem !important;
+  height: 0.9375rem !important;
 }
 
 .app-header-credit-indicator {
@@ -1515,6 +1679,26 @@ input:focus-visible {
 }
 
 @media (max-width: 64rem) {
+  .trace-search-mode-control {
+    flex: 1 0 100%;
+    width: min(100%, 20rem);
+  }
+
+  .trace-search-mode {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .trace-search-mode-menu {
+    position: static !important;
+    width: 100% !important;
+    margin-top: 0.45rem;
+  }
+
+  .landing-hero-ledger {
+    display: none !important;
+  }
+
   .demo-scene,
   .demo-final-section {
     padding-left: 1rem;
@@ -1543,6 +1727,150 @@ input:focus-visible {
 }
 
 @media (max-width: 40rem) {
+  .app-header-shared {
+    position: absolute !important;
+    top: 0.75rem;
+    right: 1rem;
+    left: 1rem;
+    width: auto !important;
+    min-height: 0 !important;
+    padding: 0.3125rem 0.375rem !important;
+    border: 0.0625rem solid color-mix(in srgb, var(--border) 72%, transparent) !important;
+    border-radius: 0.875rem;
+    background: color-mix(in srgb, var(--bg-primary) 88%, transparent) !important;
+    box-shadow: 0 0.625rem 1.75rem rgba(0, 0, 0, 0.12) !important;
+    backdrop-filter: blur(16px);
+  }
+
+  .app-header-shared .app-header-brand {
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    height: 2rem;
+    padding: 0 0.625rem;
+  }
+
+  .app-header-shared .app-header-brand svg {
+    width: 1rem;
+    height: 1rem;
+  }
+
+  .app-header-shared .app-header-brand span {
+    color: var(--text-secondary);
+    font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif !important;
+    font-size: 0.75rem !important;
+    font-weight: 500 !important;
+    letter-spacing: -0.01em !important;
+  }
+
+  .app-header-shared .app-header-query {
+    position: absolute !important;
+    top: 50%;
+    left: 50%;
+    width: calc(100% - 12rem);
+    min-width: 0;
+    transform: translate(-50%, -50%);
+    justify-content: center;
+    pointer-events: none;
+  }
+
+  .app-header-shared .app-header-actions {
+    z-index: 1;
+    gap: 0.125rem !important;
+  }
+
+  .app-header-shared .app-header-shared-action {
+    display: flex !important;
+    align-items: center;
+    justify-content: center;
+    width: 2rem !important;
+    min-width: 2rem;
+    height: 2rem !important;
+    border: none !important;
+    background: transparent !important;
+    color: var(--text-secondary) !important;
+    cursor: pointer;
+  }
+
+  .app-header-shared .app-header-shared-compact-toggle {
+    display: none !important;
+  }
+
+  .app-header-shared.app-header-compact .app-header-query {
+    width: calc(100% - 8rem) !important;
+    max-width: calc(100% - 8rem) !important;
+    padding-bottom: 0.0625rem;
+    border-bottom-color: color-mix(in srgb, var(--text-secondary) 48%, transparent);
+    opacity: 1;
+  }
+
+  .app-header-graph {
+    position: absolute !important;
+    top: 0.75rem;
+    right: 1rem;
+    left: 1rem;
+    width: auto !important;
+    min-height: 0 !important;
+    padding: 0.3125rem 0.375rem !important;
+    border: 0.0625rem solid color-mix(in srgb, var(--border) 72%, transparent) !important;
+    border-radius: 0.875rem;
+    background: color-mix(in srgb, var(--bg-primary) 88%, transparent) !important;
+    box-shadow: 0 0.625rem 1.75rem rgba(0, 0, 0, 0.12) !important;
+    backdrop-filter: blur(16px);
+  }
+
+  .app-header-graph .app-header-brand {
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    height: 2rem;
+    padding: 0 0.625rem;
+  }
+
+  .app-header-graph .app-header-brand svg {
+    width: 1rem;
+    height: 1rem;
+  }
+
+  .app-header-graph .app-header-brand span {
+    color: var(--text-secondary);
+    font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif !important;
+    font-size: 0.75rem !important;
+    font-weight: 500 !important;
+    letter-spacing: -0.01em !important;
+  }
+
+  .app-header-graph .app-header-query {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: calc(100% - 12rem);
+    min-width: 0;
+    transform: translate(-50%, -50%);
+    justify-content: center;
+    pointer-events: none;
+  }
+
+  .app-header-graph .app-header-actions {
+    z-index: 1;
+    gap: 0.125rem !important;
+  }
+
+  .app-header-graph .app-header-graph-icon-action,
+  .app-header-graph button.show-mobile {
+    width: 2rem !important;
+    height: 2rem !important;
+    border: none !important;
+    background: transparent !important;
+  }
+
+  .app-header-graph .app-header-graph-icon-action[aria-pressed="true"] {
+    background: var(--accent-soft) !important;
+    color: var(--accent) !important;
+  }
+
   /* Keep the first action visible without crowding the scroll cue. */
   .landing-hero-shell {
     min-height: 100%;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -327,9 +327,9 @@ body {
     height: 2rem;
     box-sizing: border-box;
     padding: 0 0.625rem !important;
-    border: none !important;
-    background: transparent !important;
-    color: var(--text-secondary) !important;
+    border: none;
+    background: transparent;
+    color: var(--text-secondary);
     font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif !important;
     font-size: 0.75rem !important;
     font-weight: 500 !important;
@@ -379,7 +379,7 @@ body {
     background: transparent;
   }
 
-  .app-header-graph a[aria-label="View on GitHub"] {
+  .app-header-graph .app-header-github-action {
     display: none !important;
   }
 
@@ -390,7 +390,7 @@ body {
     padding: 0 !important;
     justify-content: center !important;
     gap: 0 !important;
-    border: none !important;
+    border: none;
   }
 }
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -876,6 +876,10 @@ input:focus-visible {
   overflow: visible;
 }
 
+.landing-helix-particles-mobile {
+  display: none;
+}
+
 .landing-helix-particle-secondary {
   opacity: 0.7;
 }
@@ -1890,6 +1894,14 @@ input:focus-visible {
     width: 150vw;
     top: 48%;
     opacity: 0.7;
+  }
+
+  .landing-helix-particles-desktop {
+    display: none;
+  }
+
+  .landing-helix-particles-mobile {
+    display: block;
   }
 
   .landing-hero-title {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -188,6 +188,121 @@ body {
   color: var(--accent);
 }
 
+@media (min-width: 40.0625rem) {
+  .app-header-graph {
+    position: absolute !important;
+    inset: 0 0 auto !important;
+    width: 100%;
+    min-height: 0 !important;
+    padding: 0 !important;
+    border-bottom: none !important;
+    background: transparent !important;
+    box-shadow: none !important;
+  }
+
+  .app-header-graph .app-header-brand,
+  .app-header-graph .app-header-query {
+    display: none !important;
+  }
+
+  .app-header-graph .app-header-actions {
+    position: absolute;
+    top: 0.75rem;
+    left: 50%;
+    transform: translateX(-50%);
+    gap: 0.25rem !important;
+    width: max-content;
+    max-width: calc(100vw - 2rem);
+    padding: 0.3125rem 0.375rem;
+    border: 0.0625rem solid color-mix(in srgb, var(--border) 72%, transparent);
+    border-radius: 0.875rem;
+    background: color-mix(in srgb, var(--bg-primary) 88%, transparent);
+    box-shadow: 0 0.625rem 1.75rem rgba(0, 0, 0, 0.12);
+    backdrop-filter: blur(16px);
+    transition: padding 200ms ease, gap 200ms ease;
+  }
+
+  .app-header-graph .desktop-only {
+    display: contents !important;
+  }
+
+  .app-header-graph .app-header-labeled-action {
+    display: flex !important;
+    align-items: center;
+    justify-content: flex-start !important;
+    gap: 0.375rem !important;
+    width: auto !important;
+    min-width: 2rem;
+    height: 2rem;
+    box-sizing: border-box;
+    padding: 0 0.625rem !important;
+    border: none !important;
+    background: transparent !important;
+    color: var(--text-secondary) !important;
+    font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif !important;
+    font-size: 0.75rem !important;
+    font-weight: 500 !important;
+    line-height: 1;
+    letter-spacing: -0.01em;
+    cursor: pointer;
+    text-decoration: none;
+    transition: background 150ms ease, color 150ms ease, padding 200ms ease;
+  }
+
+  .app-header-graph .app-header-labeled-action > svg {
+    width: 1rem !important;
+    height: 1rem !important;
+    flex: 0 0 auto;
+  }
+
+  .app-header-graph .app-header-sediment-icon {
+    color: var(--accent);
+  }
+
+  .app-header-graph-query {
+    display: inline-block;
+    min-width: 0;
+    max-width: min(22vw, 20rem);
+    padding-bottom: 0.0625rem;
+    overflow: hidden;
+    border-bottom: 0.0625rem solid color-mix(in srgb, var(--text-secondary) 48%, transparent);
+    color: var(--text-secondary);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.75rem;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    transition: max-width 200ms ease, opacity 150ms ease, padding 200ms ease, border-color 150ms ease;
+  }
+
+  .app-header-compact .app-header-graph-query {
+    max-width: 0;
+    padding-bottom: 0;
+    border-bottom-color: transparent;
+    opacity: 0;
+  }
+
+  .app-header-graph .app-header-credit-indicator {
+    border: none;
+    background: transparent;
+  }
+
+  .app-header-graph a[aria-label="View on GitHub"] {
+    display: none !important;
+  }
+
+  .app-header-graph .app-header-graph-icon-action,
+  .app-header-graph .app-header-labeled-action.app-header-graph-compact-toggle {
+    width: 2rem !important;
+    min-width: 2rem;
+    padding: 0 !important;
+    justify-content: center !important;
+    gap: 0 !important;
+    border: none !important;
+  }
+}
+
 .app-header-credit-indicator {
   display: flex;
   align-items: center;

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -2570,51 +2570,6 @@ export default function Home() {
                 {searchedQuery}
               </motion.span>
 
-              {timelineData && saveState !== "idle" && (
-                <motion.span
-                  initial={{ opacity: 0, y: -4 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  exit={{ opacity: 0, y: -4 }}
-                  style={{
-                    display: "inline-flex",
-                    alignItems: "center",
-                    gap: "0.375rem",
-                    padding: "0.25rem 0.5rem",
-                    borderRadius: 999,
-                    border: "0.0625rem solid var(--border)",
-                    background: "var(--bg-secondary)",
-                    fontSize: "0.6875rem",
-                    color:
-                      saveState === "error"
-                        ? "#d16f5b"
-                        : saveState === "saved"
-                          ? "var(--accent)"
-                          : "var(--text-tertiary)",
-                    fontFamily: "'JetBrains Mono', monospace",
-                    letterSpacing: "0.03em",
-                  }}
-                >
-                  <span
-                    style={{
-                      width: "0.375rem",
-                      height: "0.375rem",
-                      borderRadius: 999,
-                      background:
-                        saveState === "error"
-                          ? "#d16f5b"
-                          : saveState === "saved"
-                            ? "var(--accent)"
-                            : "var(--text-tertiary)",
-                      opacity: saveState === "saving" ? 0.75 : 1,
-                    }}
-                  />
-                  {saveState === "saving"
-                    ? "Saving..."
-                    : saveState === "saved"
-                      ? "Saved"
-                      : "Save failed"}
-                </motion.span>
-              )}
             </div>
           )}
         </AnimatePresence>
@@ -3035,7 +2990,7 @@ export default function Home() {
                           </svg>
                           GitHub
                         </a>
-                        <ThemeToggle showLabel fullWidth />
+                        <ThemeToggle className="app-header-graph-session-theme" showLabel fullWidth />
                       </div>
                     )}
                     <p
@@ -3775,7 +3730,7 @@ export default function Home() {
                   gap: "0.625rem",
                   padding: "0.625rem 0.5rem",
                   borderRadius: "0.5rem",
-                  color: "var(--text-secondary)",
+                  color: "var(--text-primary)",
                   fontSize: "0.875rem",
                   fontFamily: "'DM Sans', sans-serif",
                   fontWeight: 500,
@@ -3792,6 +3747,9 @@ export default function Home() {
                 </svg>
                 View source
               </a>
+              {timelineData && (
+                <ThemeToggle className="app-header-mobile-menu-theme" showLabel fullWidth />
+              )}
             </motion.div>
           )}
         </AnimatePresence>
@@ -4667,6 +4625,7 @@ export default function Home() {
                 closePaperPanelSignal={closePaperPanelSignal}
                 graphId={graphId}
                 userId={userId}
+                saveState={saveState}
               />
             </motion.div>
           )}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1870,6 +1870,7 @@ export default function Home() {
   const savedGraphIdsRef = useRef<Set<string>>(new Set());
   const { compact, mobile } = useLandingViewport();
   const [isLandingHeaderCompact, setIsLandingHeaderCompact] = useState(false);
+  const [isGraphHeaderCompact, setIsGraphHeaderCompact] = useState(false);
 
   useEffect(() => {
     document.title = searchedQuery
@@ -2478,7 +2479,7 @@ export default function Home() {
     >
       {/* Top bar */}
       <motion.header
-        className={`app-header${!timelineData ? " app-header-landing" : ""}${!timelineData && isLandingHeaderCompact ? " app-header-compact" : ""}`}
+        className={`app-header${!timelineData ? " app-header-landing" : ""}${timelineData ? " app-header-graph" : ""}${(!timelineData && isLandingHeaderCompact) || (timelineData && isGraphHeaderCompact) ? " app-header-compact" : ""}`}
         initial={{ opacity: 0, y: -10 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5, ease: [0.16, 1, 0.3, 1] }}
@@ -2540,6 +2541,7 @@ export default function Home() {
         <AnimatePresence>
           {searchedQuery && (
             <div
+              className="app-header-query"
               style={{
                 display: "flex",
                 alignItems: "center",
@@ -2632,6 +2634,38 @@ export default function Home() {
             className="desktop-only"
             style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}
           >
+            {timelineData && (
+              <button
+                type="button"
+                className="app-header-labeled-action"
+                onClick={handleReset}
+                aria-label="Return to Sediment home"
+                title="Return to Sediment home"
+              >
+                <svg
+                  className="app-header-sediment-icon"
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                >
+                  <path d="M2 17l10 4 10-4" opacity="0.3" />
+                  <path d="M2 12l10 4 10-4" opacity="0.6" />
+                  <path d="M12 2L2 7l10 5 10-5L12 2z" />
+                </svg>
+                <span className="app-header-action-label">Sediment</span>
+              </button>
+            )}
+
+            {timelineData && searchedQuery && (
+              <span className="app-header-graph-query" title={searchedQuery}>
+                {searchedQuery}
+              </span>
+            )}
+
             {!timelineData && (
               <motion.button
                 type="button"
@@ -2850,7 +2884,7 @@ export default function Home() {
             {/* Settings / graph session actions */}
             <div style={{ position: "relative" }}>
               <button
-                className="app-header-labeled-action"
+                className={`app-header-labeled-action${timelineData ? " app-header-graph-icon-action" : ""}`}
                 onClick={() => {
                   if (timelineData) {
                     setSessionActionsOpen((open) => !open);
@@ -3116,6 +3150,27 @@ export default function Home() {
               </AnimatePresence>
             </div>
 
+            {timelineData && (
+              <button
+                type="button"
+                className="app-header-labeled-action app-header-graph-compact-toggle"
+                onClick={() => setIsGraphHeaderCompact((compact) => !compact)}
+                aria-label={isGraphHeaderCompact ? "Expand graph dock" : "Collapse graph dock"}
+                aria-pressed={isGraphHeaderCompact}
+                title={isGraphHeaderCompact ? "Expand dock" : "Collapse dock"}
+              >
+                {isGraphHeaderCompact ? (
+                  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    <path d="M6 2H2v4M10 2h4v4M2 10v4h4M14 10v4h-4" />
+                  </svg>
+                ) : (
+                  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" aria-hidden="true">
+                    <path d="M2 4h12M4 8h8M6 12h4" />
+                  </svg>
+                )}
+              </button>
+            )}
+
             <a
               className="app-header-labeled-action"
               href={GITHUB_REPO_URL}
@@ -3198,6 +3253,7 @@ export default function Home() {
 
             {timelineData && (
               <button
+                className="app-header-graph-icon-action"
                 onClick={handleToggleGlobalChat}
                 aria-label={globalChatOpen ? "Close timeline sidebar" : "Open timeline sidebar"}
                 aria-pressed={globalChatOpen}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -529,6 +529,102 @@ function DemoGraph({
   );
 }
 
+function buildMobileEllipsePath(
+  width: number,
+  top: number,
+  height: number,
+  scaleX: number,
+  rotationDegrees: number,
+  reverse = false,
+) {
+  const centerX = width / 2;
+  const centerY = top + height / 2;
+  const radiusX = width / 2;
+  const radiusY = height / 2;
+  const rotation = (rotationDegrees * Math.PI) / 180;
+  const steps = 180;
+  const points = Array.from({ length: steps + 1 }, (_, index) => {
+    const progress = index / steps;
+    const angle = (reverse ? -progress : progress) * Math.PI * 2;
+    const x = radiusX * Math.cos(angle) * scaleX;
+    const y = radiusY * Math.sin(angle);
+    return [
+      centerX + Math.cos(rotation) * x - Math.sin(rotation) * y,
+      centerY + Math.sin(rotation) * x + Math.cos(rotation) * y,
+    ];
+  });
+
+  return points
+    .map(([x, y], index) => `${index === 0 ? "M" : "L"}${x.toFixed(2)} ${y.toFixed(2)}`)
+    .join(" ");
+}
+
+function MobileLandingHelixParticles() {
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const [frame, setFrame] = useState({ width: 1, height: 1, paths: ["", ""] });
+
+  useEffect(() => {
+    const svg = svgRef.current;
+    const strata = svg?.parentElement;
+    if (!svg || !strata) return;
+
+    const updatePaths = () => {
+      const ellipseElements = Array.from(strata.querySelectorAll(":scope > span"));
+      const width = strata.clientWidth;
+      const height = strata.clientHeight;
+      if (!width || !height || ellipseElements.length < 3) return;
+
+      const primary = ellipseElements[0];
+      const secondary = ellipseElements[2];
+      setFrame({
+        width,
+        height,
+        paths: [
+          buildMobileEllipsePath(width, primary.offsetTop, primary.offsetHeight, 0.84, -5),
+          buildMobileEllipsePath(width, secondary.offsetTop, secondary.offsetHeight, 0.76, -3, true),
+        ],
+      });
+    };
+
+    updatePaths();
+    const observer = new ResizeObserver(updatePaths);
+    observer.observe(strata);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <svg
+      ref={svgRef}
+      className="landing-helix-particles landing-helix-particles-mobile"
+      viewBox={`0 0 ${frame.width} ${frame.height}`}
+      preserveAspectRatio="none"
+    >
+      {frame.paths.map((path, index) => path && (
+        <g
+          key={index}
+          className={`landing-helix-particle${index === 1 ? " landing-helix-particle-secondary" : ""}`}
+        >
+          <animateMotion
+            dur="26s"
+            begin={index === 1 ? "-13s" : undefined}
+            repeatCount="indefinite"
+            path={path}
+          />
+          <animate
+            attributeName="opacity"
+            values={index === 1 ? "0;0.7;0.7;0" : "0;0.9;0.9;0"}
+            keyTimes="0;0.035;0.96;1"
+            dur="26s"
+            begin={index === 1 ? "-13s" : undefined}
+            repeatCount="indefinite"
+          />
+          <circle className="landing-helix-core" r="4.25" />
+        </g>
+      ))}
+    </svg>
+  );
+}
+
 function LandingScrollHint({
   containerRef,
 }: {
@@ -4295,7 +4391,7 @@ export default function Home() {
                   <span />
                   <span />
                   <svg
-                    className="landing-helix-particles"
+                    className="landing-helix-particles landing-helix-particles-desktop"
                     viewBox="0 0 1248 448"
                     preserveAspectRatio="none"
                   >
@@ -4332,6 +4428,7 @@ export default function Home() {
                       <circle className="landing-helix-core" r="4.25" />
                     </g>
                   </svg>
+                  <MobileLandingHelixParticles />
                 </div>
 
                 <div className="landing-hero-content">

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -3223,7 +3223,7 @@ export default function Home() {
             )}
 
             <a
-              className="app-header-labeled-action"
+              className="app-header-labeled-action app-header-github-action"
               href={GITHUB_REPO_URL}
               target="_blank"
               rel="noopener noreferrer"

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -569,7 +569,9 @@ function MobileLandingHelixParticles() {
     if (!svg || !strata) return;
 
     const updatePaths = () => {
-      const ellipseElements = Array.from(strata.querySelectorAll(":scope > span"));
+      const ellipseElements = Array.from(
+        strata.querySelectorAll<HTMLElement>(":scope > span"),
+      );
       const width = strata.clientWidth;
       const height = strata.clientHeight;
       if (!width || !height || ellipseElements.length < 3) return;

--- a/frontend/src/app/s/[share_id]/page.tsx
+++ b/frontend/src/app/s/[share_id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useParams } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
 import { TimelineCanvas } from "@/components/TimelineCanvas";
@@ -23,6 +23,7 @@ export default function SharedGraphPage() {
   const [error, setError] = useState("");
   const [sessionActionsOpen, setSessionActionsOpen] = useState(false);
   const [isHeaderCompact, setIsHeaderCompact] = useState(false);
+  const sessionActionsRef = useRef<HTMLDivElement>(null);
   const { hoverPreviewEnabled, onToggleHoverPreview } = useHoverPreviewToggle();
 
   useEffect(() => {
@@ -44,6 +45,30 @@ export default function SharedGraphPage() {
         setIsLoading(false);
       });
   }, [shareId]);
+
+  useEffect(() => {
+    if (!sessionActionsOpen) return;
+
+    const dismissIfOutside = (target: EventTarget | null) => {
+      if (target instanceof Node && !sessionActionsRef.current?.contains(target)) {
+        setSessionActionsOpen(false);
+      }
+    };
+    const onPointerDown = (event: PointerEvent) => dismissIfOutside(event.target);
+    const onFocusIn = (event: FocusEvent) => dismissIfOutside(event.target);
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setSessionActionsOpen(false);
+    };
+
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("focusin", onFocusIn);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("focusin", onFocusIn);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [sessionActionsOpen]);
 
   return (
     <div
@@ -154,7 +179,7 @@ export default function SharedGraphPage() {
         {/* Right side */}
         <div className="app-header-actions" style={{ display: "flex", alignItems: "center", gap: "0.5rem", flexShrink: 0 }}>
 
-          <div style={{ position: "relative" }}>
+          <div ref={sessionActionsRef} style={{ position: "relative" }}>
             <button
               type="button"
               className="app-header-shared-action app-header-shared-icon-action"

--- a/frontend/src/app/s/[share_id]/page.tsx
+++ b/frontend/src/app/s/[share_id]/page.tsx
@@ -21,7 +21,8 @@ export default function SharedGraphPage() {
   const [query, setQuery] = useState("");
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState("");
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [sessionActionsOpen, setSessionActionsOpen] = useState(false);
+  const [isHeaderCompact, setIsHeaderCompact] = useState(false);
   const { hoverPreviewEnabled, onToggleHoverPreview } = useHoverPreviewToggle();
 
   useEffect(() => {
@@ -46,7 +47,7 @@ export default function SharedGraphPage() {
 
   return (
     <div
-      className="grain"
+      className="grain app-shell"
       style={{
         height: "100vh",
         display: "flex",
@@ -55,6 +56,7 @@ export default function SharedGraphPage() {
       }}
     >
       <motion.header
+        className={`app-header app-header-shared${isHeaderCompact ? " app-header-compact" : ""}`}
         initial={{ opacity: 0, y: -10 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5, ease: [0.16, 1, 0.3, 1] }}
@@ -74,6 +76,7 @@ export default function SharedGraphPage() {
         {/* Logo */}
         <a
           href="/"
+          className="app-header-brand"
           style={{
             display: "flex",
             alignItems: "center",
@@ -103,7 +106,7 @@ export default function SharedGraphPage() {
         {/* Centered query label — desktop only */}
         {query && (
           <span
-            className="hide-mobile"
+            className="hide-mobile app-header-query app-header-shared-query"
             style={{
               position: "absolute",
               left: "50%",
@@ -127,7 +130,7 @@ export default function SharedGraphPage() {
         {/* Mobile: query label truncates between logo and buttons */}
         {query && (
           <div
-            className="show-mobile"
+            className="show-mobile app-header-query app-header-shared-query"
             style={{ flex: 1, minWidth: 0, overflow: "hidden" }}
           >
             <span
@@ -149,157 +152,94 @@ export default function SharedGraphPage() {
         )}
 
         {/* Right side */}
-        <div style={{ display: "flex", alignItems: "center", gap: "0.5rem", flexShrink: 0 }}>
+        <div className="app-header-actions" style={{ display: "flex", alignItems: "center", gap: "0.5rem", flexShrink: 0 }}>
 
-          {/* Desktop buttons */}
-          <div className="desktop-only" style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
-            <a
-              href={GITHUB_REPO_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="View on GitHub"
-              style={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                width: "2rem",
-                height: "2rem",
-                borderRadius: "0.4375rem",
-                border: "0.0625rem solid var(--border)",
-                color: "var(--text-secondary)",
-                transition: "border-color 0.15s, color 0.15s",
-                flexShrink: 0,
-              }}
-              onMouseEnter={(e) => { (e.currentTarget as HTMLAnchorElement).style.borderColor = "var(--accent)"; (e.currentTarget as HTMLAnchorElement).style.color = "var(--accent)"; }}
-              onMouseLeave={(e) => { (e.currentTarget as HTMLAnchorElement).style.borderColor = "var(--border)"; (e.currentTarget as HTMLAnchorElement).style.color = "var(--text-secondary)"; }}
-            >
-              <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
-              </svg>
-            </a>
-
-            {timelineData && query && (
-              <button
-                onClick={() => exportObsidianZip(timelineData, query).catch(() => alert("Export failed."))}
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: "0.375rem",
-                  padding: "0 0.75rem",
-                  height: "2rem",
-                  boxSizing: "border-box",
-                  background: "none",
-                  border: "0.0625rem solid var(--border)",
-                  borderRadius: "0.4375rem",
-                  color: "var(--text-secondary)",
-                  fontSize: "0.75rem",
-                  fontFamily: "'DM Sans', sans-serif",
-                  fontWeight: 500,
-                  cursor: "pointer",
-                  transition: "border-color 0.15s, color 0.15s",
-                }}
-                onMouseEnter={(e) => { e.currentTarget.style.borderColor = "var(--accent)"; e.currentTarget.style.color = "var(--accent)"; }}
-                onMouseLeave={(e) => { e.currentTarget.style.borderColor = "var(--border)"; e.currentTarget.style.color = "var(--text-secondary)"; }}
-              >
-                <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M8 2v9M4 7l4 4 4-4" /><path d="M2 13h12" />
-                </svg>
-                Export
-              </button>
-            )}
-          </div>
-
-          {/* Always visible: theme toggle + mobile hamburger */}
-          <div style={{ display: "flex", alignItems: "center", gap: "0.375rem" }}>
-            <ThemeToggle />
-
+          <div style={{ position: "relative" }}>
             <button
-              className="show-mobile"
-              onClick={() => setMobileMenuOpen((o) => !o)}
-              aria-label="Menu"
-              style={{
-                display: "flex",
-                flexDirection: "column",
-                alignItems: "center",
-                justifyContent: "center",
-                gap: "0.3rem",
-                width: "2rem",
-                height: "2rem",
-                background: mobileMenuOpen ? "var(--accent-soft)" : "none",
-                border: `0.0625rem solid ${mobileMenuOpen ? "var(--accent)" : "var(--border)"}`,
-                borderRadius: "0.4375rem",
-                cursor: "pointer",
-                padding: 0,
-                transition: "border-color 0.15s, background 0.15s",
-              }}
+              type="button"
+              className="app-header-shared-action app-header-shared-icon-action"
+              onClick={() => setSessionActionsOpen((open) => !open)}
+              aria-label="Session actions"
+              aria-expanded={sessionActionsOpen}
+              title="Session actions"
             >
-              {mobileMenuOpen ? (
-                <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke={mobileMenuOpen ? "var(--accent)" : "var(--text-secondary)"} strokeWidth="1.75" strokeLinecap="round">
-                  <path d="M2 2l10 10M12 2L2 12" />
-                </svg>
-              ) : (
-                <svg width="14" height="12" viewBox="0 0 14 12" fill="none" stroke="var(--text-secondary)" strokeWidth="1.5" strokeLinecap="round">
-                  <path d="M1 1h12M1 6h12M1 11h12" />
-                </svg>
-              )}
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                <circle cx="3" cy="8" r="1.35" />
+                <circle cx="8" cy="8" r="1.35" />
+                <circle cx="13" cy="8" r="1.35" />
+              </svg>
             </button>
-          </div>
-        </div>
 
-        {/* Mobile dropdown */}
-        <AnimatePresence>
-          {mobileMenuOpen && (
-            <motion.div
-              initial={{ opacity: 0, y: -8 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -8 }}
-              transition={{ duration: 0.2, ease: [0.16, 1, 0.3, 1] }}
-              className="show-mobile"
-              style={{
-                position: "absolute",
-                top: "100%",
-                left: 0,
-                right: 0,
-                background: "var(--bg-primary)",
-                borderBottom: "0.0625rem solid var(--border)",
-                boxShadow: "0 0.5rem 1.5rem rgba(0,0,0,0.12)",
-                zIndex: 200,
-                padding: "0.375rem 1rem 0.625rem",
-                display: "flex",
-                flexDirection: "column",
-                gap: "0.25rem",
-              }}
-            >
-              {timelineData && query && (
-                <button
-                  onClick={() => { exportObsidianZip(timelineData, query).catch(() => alert("Export failed.")); setMobileMenuOpen(false); }}
-                  style={{ display: "flex", alignItems: "center", gap: "0.625rem", width: "100%", padding: "0.625rem 0.5rem", background: "none", border: "none", borderRadius: "0.5rem", color: "var(--text-primary)", fontSize: "0.875rem", fontFamily: "'DM Sans', sans-serif", fontWeight: 500, cursor: "pointer", textAlign: "left" }}
-                  onTouchStart={(e) => { e.currentTarget.style.background = "var(--bg-secondary)"; }}
-                  onTouchEnd={(e) => { e.currentTarget.style.background = "none"; }}
-                  onTouchCancel={(e) => { e.currentTarget.style.background = "none"; }}
+            <AnimatePresence>
+              {sessionActionsOpen && (
+                <motion.div
+                  initial={{ opacity: 0, y: -6, scale: 0.98 }}
+                  animate={{ opacity: 1, y: 0, scale: 1 }}
+                  exit={{ opacity: 0, y: -6, scale: 0.98 }}
+                  transition={{ duration: 0.15, ease: "easeOut" }}
+                  style={{
+                    position: "absolute",
+                    top: "2.5rem",
+                    right: 0,
+                    width: "14rem",
+                    padding: "0.875rem",
+                    background: "var(--bg-secondary)",
+                    border: "0.0625rem solid var(--border-hover)",
+                    borderRadius: "0.625rem",
+                    boxShadow: "0 0.5rem 1.5rem rgba(0,0,0,0.10), 0 0.125rem 0.375rem rgba(0,0,0,0.06)",
+                    zIndex: 100,
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: "0.125rem",
+                  }}
                 >
-                  <svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="var(--text-tertiary)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-                    <path d="M8 2v9M4 7l4 4 4-4" /><path d="M2 13h12" />
-                  </svg>
-                  Export to Obsidian
-                </button>
+                  <p style={{ marginBottom: "0.375rem", fontSize: "0.625rem", color: "var(--text-tertiary)", fontFamily: "'JetBrains Mono', monospace", letterSpacing: "0.06em", textTransform: "uppercase" }}>
+                    Session actions
+                  </p>
+                  {timelineData && query && (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        exportObsidianZip(timelineData, query).catch(() => alert("Export failed."));
+                        setSessionActionsOpen(false);
+                      }}
+                      style={{ display: "flex", alignItems: "center", gap: "0.625rem", width: "100%", height: "2rem", padding: "0 0.5rem", border: "none", borderRadius: "0.375rem", background: "none", color: "var(--text-primary)", cursor: "pointer", fontFamily: "'DM Sans', sans-serif", fontSize: "0.75rem", fontWeight: 500, textAlign: "left" }}
+                    >
+                      <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="var(--text-tertiary)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><path d="M8 2v9M4 7l4 4 4-4" /><path d="M2 13h12" /></svg>
+                      Export
+                    </button>
+                  )}
+                  <a
+                    href={GITHUB_REPO_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={() => setSessionActionsOpen(false)}
+                    style={{ display: "flex", alignItems: "center", gap: "0.625rem", width: "100%", height: "2rem", padding: "0 0.5rem", borderRadius: "0.375rem", color: "var(--text-primary)", fontFamily: "'DM Sans', sans-serif", fontSize: "0.75rem", fontWeight: 500, textDecoration: "none" }}
+                  >
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" style={{ color: "var(--text-tertiary)" }} aria-hidden="true"><path d="M12 2a10 10 0 0 0-3.16 19.49c.5.09.68-.22.68-.48v-1.7c-2.78.6-3.36-1.34-3.36-1.34-.45-1.15-1.1-1.46-1.1-1.46-.9-.62.07-.61.07-.61 1 .07 1.53 1.03 1.53 1.03.89 1.53 2.34 1.09 2.91.83.09-.65.35-1.09.63-1.34-2.22-.25-4.55-1.11-4.55-4.94 0-1.09.39-1.98 1.03-2.68-.1-.25-.45-1.27.1-2.65 0 0 .84-.27 2.75 1.02A9.5 9.5 0 0 1 12 6.84c.85 0 1.71.11 2.5.34 1.91-1.29 2.75-1.02 2.75-1.02.55 1.38.2 2.4.1 2.65.64.7 1.03 1.59 1.03 2.68 0 3.84-2.34 4.69-4.57 4.94.36.31.68.92.68 1.85v2.74c0 .27.18.58.69.48A10 10 0 0 0 12 2z" /></svg>
+                    GitHub
+                  </a>
+                  <ThemeToggle className="app-header-shared-session-theme" showLabel fullWidth />
+                </motion.div>
               )}
+            </AnimatePresence>
+          </div>
 
-              <a
-                href={GITHUB_REPO_URL}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={() => setMobileMenuOpen(false)}
-                style={{ display: "flex", alignItems: "center", gap: "0.625rem", padding: "0.625rem 0.5rem", borderRadius: "0.5rem", color: "var(--text-secondary)", fontSize: "0.875rem", fontFamily: "'DM Sans', sans-serif", fontWeight: 500, textDecoration: "none" }}
-              >
-                <svg width="15" height="15" viewBox="0 0 24 24" fill="var(--text-tertiary)">
-                  <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
-                </svg>
-                View source
-              </a>
-            </motion.div>
-          )}
-        </AnimatePresence>
+          <button
+            type="button"
+            className="app-header-shared-action app-header-shared-icon-action app-header-shared-compact-toggle"
+            onClick={() => setIsHeaderCompact((compact) => !compact)}
+            aria-label={isHeaderCompact ? "Expand shared graph dock" : "Collapse shared graph dock"}
+            aria-pressed={isHeaderCompact}
+            title={isHeaderCompact ? "Expand dock" : "Collapse dock"}
+          >
+            {isHeaderCompact ? (
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M6 2H2v4M10 2h4v4M2 10v4h4M14 10v4h-4" /></svg>
+            ) : (
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" aria-hidden="true"><path d="M2 4h12M4 8h8M6 12h4" /></svg>
+            )}
+          </button>
+        </div>
       </motion.header>
 
       <div style={{ flex: 1, overflow: "hidden", position: "relative" }}>

--- a/frontend/src/components/GlobalChatPanel.tsx
+++ b/frontend/src/components/GlobalChatPanel.tsx
@@ -275,6 +275,9 @@ export function GlobalChatPanel({ data, open, onOpenChange, onHighlight, onMenti
     year: n.paper.year,
     summary: n.paper.summary,
   }));
+  const noteCount = Object.values(data.notes ?? {}).filter(
+    (note) => note.id && note.text.trim(),
+  ).length;
   const mentionOptions = papers
     .filter((paper) => !mentionedPaperIds.includes(paper.openalexId))
     .filter((paper) => {
@@ -613,6 +616,7 @@ export function GlobalChatPanel({ data, open, onOpenChange, onHighlight, onMenti
 
             {/* Header */}
             <div style={{
+              position: "relative",
               display: "flex",
               alignItems: "center",
               gap: "0.5rem",
@@ -620,10 +624,7 @@ export function GlobalChatPanel({ data, open, onOpenChange, onHighlight, onMenti
               borderBottom: "0.0625rem solid var(--border)",
               flexShrink: 0,
             }}>
-              <motion.div
-                initial={false}
-                animate={{ rotate: 180 }}
-                transition={{ duration: 0.45, ease: [0.16, 1, 0.3, 1] }}
+              <div
                 style={{
                   width: "1.25rem",
                   height: "1.25rem",
@@ -633,20 +634,18 @@ export function GlobalChatPanel({ data, open, onOpenChange, onHighlight, onMenti
                   flexShrink: 0,
                 }}
               >
-                <svg width="14" height="14" viewBox="0 0 20 20" fill="none">
-                  <rect x="2"  y="4"  width="16" height="3" rx="1.5" fill="var(--accent)" opacity="1" />
-                  <rect x="4"  y="9"  width="12" height="3" rx="1.5" fill="var(--accent)" opacity="0.7" />
-                  <rect x="6"  y="14" width="8"  height="3" rx="1.5" fill="var(--accent)" opacity="0.4" />
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" strokeWidth="1.5" strokeLinecap="round" aria-hidden="true">
+                  <path d="M2 17l10 4 10-4" opacity="0.3" />
+                  <path d="M2 12l10 4 10-4" opacity="0.6" />
+                  <path d="M12 2L2 7l10 5 10-5L12 2z" />
                 </svg>
-              </motion.div>
-              <div style={{ flex: 1 }}>
+              </div>
+              <div style={{ position: "absolute", left: "50%", transform: "translateX(-50%)", maxWidth: "calc(100% - 7rem)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", pointerEvents: "none" }}>
                 <div style={{ fontSize: "0.75rem", fontWeight: 600, color: "var(--text-primary)", fontFamily: "'DM Sans', sans-serif" }}>
-                  Timeline chat
-                </div>
-                <div style={{ fontSize: "0.625rem", color: "var(--text-tertiary)", fontFamily: "'JetBrains Mono', monospace", letterSpacing: "0.03em" }}>
-                  Ask globally, or mention papers with @
+                  Sediment Agent
                 </div>
               </div>
+              <div style={{ flex: 1 }} />
               <button
                 onClick={handleClose}
                 aria-label="Close chat"
@@ -692,7 +691,7 @@ export function GlobalChatPanel({ data, open, onOpenChange, onHighlight, onMenti
                     fontFamily: "'JetBrains Mono', monospace",
                   }}
                 >
-                  {papers.length} paper{papers.length !== 1 ? "s" : ""}
+                  {papers.length} paper{papers.length !== 1 ? "s" : ""} · {noteCount} note{noteCount !== 1 ? "s" : ""}
                 </span>
               </div>
               <div style={{ display: "flex", flexWrap: "wrap", gap: "0.375rem" }}>

--- a/frontend/src/components/SearchInput.tsx
+++ b/frontend/src/components/SearchInput.tsx
@@ -273,7 +273,7 @@ export function SearchInput({ onSearch, isSearching, traceMode, onTraceModeChang
             {example}
           </motion.button>
         ))}
-        <div style={{ position: "relative", zIndex: 3 }}>
+        <div className="trace-search-mode-control" style={{ position: "relative", zIndex: 3 }}>
           <button
             type="button"
             className="trace-search-mode"
@@ -333,6 +333,7 @@ export function SearchInput({ onSearch, isSearching, traceMode, onTraceModeChang
           <AnimatePresence>
             {modeOpen && (
               <motion.div
+                className="trace-search-mode-menu"
                 initial={{ opacity: 0, y: -5, scale: 0.98 }}
                 animate={{ opacity: 1, y: 0, scale: 1 }}
                 exit={{ opacity: 0, y: -5, scale: 0.98 }}

--- a/frontend/src/components/SearchInput.tsx
+++ b/frontend/src/components/SearchInput.tsx
@@ -7,6 +7,7 @@ const EXAMPLES = [
   "Transformer",
   "VLMs",
   "Feynman Path Integrals",
+  "CRISPR",
 ];
 
 interface SearchInputProps {
@@ -230,7 +231,7 @@ export function SearchInput({ onSearch, isSearching, traceMode, onTraceModeChang
         {EXAMPLES.map((example, i) => (
           <motion.button
             key={example}
-            className={`trace-search-suggestion${example === "Feynman Path Integrals" ? " hide-mobile" : ""}`}
+            className={`trace-search-suggestion${example === "Feynman Path Integrals" ? " hide-mobile" : ""}${example === "CRISPR" ? " show-mobile" : ""}`}
             type="button"
             disabled={isSearching}
             onClick={() => onSearch(example)}

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -39,7 +39,8 @@ export function ThemeToggle({
         transition: "border-color 0.15s, color 0.15s",
       }}
       onMouseEnter={(e) => {
-        if (!fullWidth) e.currentTarget.style.borderColor = "var(--accent)";
+        if (fullWidth) return;
+        e.currentTarget.style.borderColor = "var(--accent)";
         e.currentTarget.style.color = "var(--accent)";
       }}
       onMouseLeave={(e) => {

--- a/frontend/src/components/TimelineCanvas.tsx
+++ b/frontend/src/components/TimelineCanvas.tsx
@@ -54,6 +54,7 @@ interface TimelineCanvasProps {
   closePaperPanelSignal?: number;
   graphId?: string | null;
   userId?: string | null;
+  saveState?: "idle" | "saving" | "saved" | "error";
 }
 
 interface HoverPreviewState {
@@ -87,6 +88,7 @@ export function TimelineCanvas({
   closePaperPanelSignal = 0,
   graphId,
   userId,
+  saveState = "idle",
 }: TimelineCanvasProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -1277,6 +1279,59 @@ export function TimelineCanvas({
             </svg>
           </button>
         )}
+
+        <AnimatePresence>
+          {saveState !== "idle" && (
+            <motion.div
+              initial={{ opacity: 0, x: -4 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: -4 }}
+              transition={{ duration: 0.16, ease: "easeOut" }}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: "0.375rem",
+                height: "1.75rem",
+                boxSizing: "border-box",
+                marginLeft: "0.25rem",
+                padding: "0 0.5rem",
+                borderRadius: "0.375rem",
+                border: "0.0625rem solid var(--border)",
+                background: "var(--bg-secondary)",
+                color:
+                  saveState === "error"
+                    ? "#d16f5b"
+                    : saveState === "saved"
+                      ? "var(--accent)"
+                      : "var(--text-tertiary)",
+                fontFamily: "'JetBrains Mono', monospace",
+                fontSize: "0.6875rem",
+                letterSpacing: "0.03em",
+                userSelect: "none",
+              }}
+            >
+              <span
+                style={{
+                  width: "0.375rem",
+                  height: "0.375rem",
+                  borderRadius: "50%",
+                  background:
+                    saveState === "error"
+                      ? "#d16f5b"
+                      : saveState === "saved"
+                        ? "var(--accent)"
+                        : "var(--text-tertiary)",
+                  opacity: saveState === "saving" ? 0.75 : 1,
+                }}
+              />
+              {saveState === "saving"
+                ? "Saving..."
+                : saveState === "saved"
+                  ? "Saved"
+                  : "Save failed"}
+            </motion.div>
+          )}
+        </AnimatePresence>
       </div>
 
       <svg

--- a/frontend/src/components/TimelineCanvas.tsx
+++ b/frontend/src/components/TimelineCanvas.tsx
@@ -1283,6 +1283,7 @@ export function TimelineCanvas({
         <AnimatePresence>
           {saveState !== "idle" && (
             <motion.div
+              key="timeline-save-status"
               initial={{ opacity: 0, x: -4 }}
               animate={{ opacity: 1, x: 0 }}
               exit={{ opacity: 0, x: -4 }}

--- a/frontend/src/components/TimelineNote.tsx
+++ b/frontend/src/components/TimelineNote.tsx
@@ -182,23 +182,13 @@ export function TimelineNoteCard({
           background: colorStyle.background,
           boxShadow: isDragging
             ? "0 1.125rem 2.5rem rgba(0,0,0,0.24), 0 0 0 0.1875rem var(--accent-soft)"
-            : "0 0.75rem 2rem rgba(0,0,0,0.18), inset 0 0.0625rem 0 rgba(255,255,255,0.05)",
+            : "0 0.5rem 1.25rem rgba(0,0,0,0.18)",
           overflow: "visible",
           userSelect: isDragging ? "none" : "auto",
           display: "flex",
           flexDirection: "column",
         }}
       >
-        <div
-          style={{
-            position: "absolute",
-            inset: 0,
-            background:
-              "radial-gradient(circle at 16% 10%, rgba(255,255,255,0.08), transparent 34%), linear-gradient(135deg, rgba(255,255,255,0.035), transparent 42%)",
-            pointerEvents: "none",
-          }}
-        />
-
         <div
           style={{
             position: "relative",
@@ -212,7 +202,7 @@ export function TimelineNoteCard({
           {readOnly ? (
             <span
               style={{
-                fontSize: "0.5625rem",
+                fontSize: "0.625rem",
                 fontFamily: "'JetBrains Mono', monospace",
                 letterSpacing: "0.12em",
                 textTransform: "uppercase",
@@ -243,7 +233,7 @@ export function TimelineNoteCard({
                   background: "transparent",
                   color: colorStyle.accent,
                   cursor: "pointer",
-                  fontSize: "0.5625rem",
+                  fontSize: "0.625rem",
                   fontFamily: "'JetBrains Mono', monospace",
                   letterSpacing: "0.12em",
                   textTransform: "uppercase",
@@ -320,9 +310,9 @@ export function TimelineNoteCard({
           <span
             title={`${connectedNodeCount} connected node${connectedNodeCount === 1 ? "" : "s"}`}
             style={{
-              fontSize: "0.5625rem",
+              fontSize: "0.625rem",
               fontFamily: "'JetBrains Mono', monospace",
-              color: "var(--text-tertiary)",
+              color: "var(--text-secondary)",
               whiteSpace: "nowrap",
             }}
           >
@@ -349,10 +339,11 @@ export function TimelineNoteCard({
               outline: "none",
               background: "transparent",
               color: "var(--text-primary)",
-              fontFamily: "'Instrument Serif', Georgia, serif",
-              fontSize: "1.0625rem",
-              lineHeight: 1.32,
-              letterSpacing: "-0.01em",
+              fontFamily: "'DM Sans', sans-serif",
+              fontSize: "0.9375rem",
+              fontWeight: 500,
+              lineHeight: 1.5,
+              letterSpacing: 0,
               padding: "0.5rem 0.75rem",
               cursor: "text",
             }}
@@ -384,10 +375,11 @@ export function TimelineNoteCard({
             <MarkdownContent
               style={{
                 color: "var(--text-primary)",
-                fontFamily: "'Instrument Serif', Georgia, serif",
-                fontSize: "1.0625rem",
-                lineHeight: 1.32,
-                letterSpacing: "-0.01em",
+                fontFamily: "'DM Sans', sans-serif",
+                fontSize: "0.9375rem",
+                fontWeight: 500,
+                lineHeight: 1.5,
+                letterSpacing: 0,
                 overflowWrap: "break-word",
               }}
             >


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added graph-mode app header controls, including a labeled “Sediment” home button and an expand/collapse toggle.
  * Updated the shared graph header with a compact state and an actions dropdown (including export when available).
  * Added a “Saving/Saved/Save failed” status pill to the timeline canvas.
  * Improved landing helix particles for better mobile responsiveness.

* **Style**
  * Refreshed header layout/labels across desktop, mobile, and shared views.
  * Updated timeline note typography, link counter styling, and dragging emphasis.
  * Enhanced chat context display (paper/note counts) and adjusted theme toggle hover behavior.
  * Tweaked search suggestion examples and trace-mode styling hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->