### PR TITLE
Redirect legacy Vercel domain

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -5,6 +5,21 @@ const nextConfig: NextConfig = {
   turbopack: {
     root: __dirname,
   },
+  async redirects() {
+    return [
+      {
+        source: "/:path*",
+        has: [
+          {
+            type: "host",
+            value: "sediment-seven\\.vercel\\.app",
+          },
+        ],
+        destination: "https://sediment-ai.com/:path*",
+        permanent: true,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added permanent redirects from the previous website domain to the new `sediment-ai.com` domain.
  * Preserved the requested page path during redirection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->